### PR TITLE
add missing PNY XLR8 Gaming non-RGB DDR5

### DIFF
--- a/open-db/RAM/7bba90ae-9299-4ca0-adea-b4f2b514f820.json
+++ b/open-db/RAM/7bba90ae-9299-4ca0-adea-b4f2b514f820.json
@@ -1,0 +1,33 @@
+{
+  "opendb_id": "7bba90ae-9299-4ca0-adea-b4f2b514f820",
+  "modules": {
+    "quantity": 2,
+    "capacity_gb": 32
+  },
+  "metadata": {
+    "name": "PNY XLR8 Gaming Black DDR5-5600 CL46 32GB (2x16GB)",
+    "manufacturer": "PNY",
+    "part_numbers": [
+      "MD32GK2D5560046XR"
+    ],
+    "series": "XLR8",
+    "variant": "5600 CL46"
+  },
+  "speed": 5600,
+  "ram_type": "DDR5",
+  "form_factor": "288-pin DIMM (DDR5)",
+  "capacity": 32,
+  "color": [
+    "BLACK"
+  ],
+  "cas_latency": 46,
+  "voltage": 1.1,
+  "ecc": "Non-ECC",
+  "registered": "Unbuffered",
+  "heat_spreader": true,
+  "rgb": false,
+  "general_product_information": {
+    "amazon_sku": "B0DTZ522Q6",
+    "manufacturer_url": "https://www.pny.com/XLR8-Gaming-DDR5-5600-MHz-Desktop-Memory-Kit?sku=MD32GK2D5560046XR"
+  }
+}

--- a/open-db/RAM/d0ac0a02-4eb1-46b6-b3be-e746edbb6668.json
+++ b/open-db/RAM/d0ac0a02-4eb1-46b6-b3be-e746edbb6668.json
@@ -1,0 +1,33 @@
+{
+	"opendb_id": "e5535098-c996-4edd-83ce-091d4f400acd",
+	"modules": {
+	  "quantity": 2,
+	  "capacity_gb": 32
+	},
+	"metadata": {
+	  "name": "PNY XLR8 Gaming Black DDR5-6400 CL36 32GB (2x16GB)",
+	  "manufacturer": "PNY",
+	  "part_numbers": [
+		"MD32GK2D5640036XR"
+	  ],
+	  "series": "XLR8",
+	  "variant": "6400 CL36"
+	},
+	"speed": 6400,
+	"ram_type": "DDR5",
+	"form_factor": "288-pin DIMM (DDR5)",
+	"capacity": 32,
+	"color": [
+	  "BLACK"
+	],
+	"cas_latency": 36,
+	"voltage": 1.4,
+	"ecc": "Non-ECC",
+	"registered": "Unbuffered",
+	"heat_spreader": true,
+	"rgb": false,
+	"general_product_information": {
+	  "amazon_sku": "B0DTZ6SPNW",
+	  "manufacturer_url": "https://www.pny.com/xlr8-gaming-ddr5-6400-mhz-desktop-memory-kit"
+	}
+  }

--- a/open-db/RAM/e5535098-c996-4edd-83ce-091d4f400acd.json
+++ b/open-db/RAM/e5535098-c996-4edd-83ce-091d4f400acd.json
@@ -1,0 +1,32 @@
+{
+	"opendb_id": "e5535098-c996-4edd-83ce-091d4f400acd",
+	"modules": {
+	  "quantity": 2,
+	  "capacity_gb": 32
+	},
+	"metadata": {
+	  "name": "PNY XLR8 Gaming Black DDR5-5600 CL36 32GB (2x16GB)",
+	  "manufacturer": "PNY",
+	  "part_numbers": [
+		"MD32GK2D5560036XR"
+	  ],
+	  "series": "XLR8",
+	  "variant": "5600 CL36"
+	},
+	"speed": 5600,
+	"ram_type": "DDR5",
+	"form_factor": "288-pin DIMM (DDR5)",
+	"capacity": 32,
+	"color": [
+	  "BLACK"
+	],
+	"cas_latency": 36,
+	"voltage": 1.25,
+	"ecc": "Non-ECC",
+	"registered": "Unbuffered",
+	"heat_spreader": true,
+	"rgb": false,
+	"general_product_information": {
+	  "manufacturer_url": "https://www.pny.com/XLR8-Gaming-DDR5-5600-MHz-Desktop-Memory-Kit?sku=MD32GK2D5560036XR"
+	}
+  }

--- a/open-db/RAM/e6113e6b-7362-4373-831d-106e1dfd6be6.json
+++ b/open-db/RAM/e6113e6b-7362-4373-831d-106e1dfd6be6.json
@@ -1,0 +1,33 @@
+{
+	"opendb_id": "e5535098-c996-4edd-83ce-091d4f400acd",
+	"modules": {
+	  "quantity": 2,
+	  "capacity_gb": 32
+	},
+	"metadata": {
+	  "name": "PNY XLR8 Gaming Black DDR5-6000 CL36 32GB (2x16GB)",
+	  "manufacturer": "PNY",
+	  "part_numbers": [
+		"MD32GK2D5600036XR"
+	  ],
+	  "series": "XLR8",
+	  "variant": "6000 CL36"
+	},
+	"speed": 6000,
+	"ram_type": "DDR5",
+	"form_factor": "288-pin DIMM (DDR5)",
+	"capacity": 32,
+	"color": [
+	  "BLACK"
+	],
+	"cas_latency": 36,
+	"voltage": 1.35,
+	"ecc": "Non-ECC",
+	"registered": "Unbuffered",
+	"heat_spreader": true,
+	"rgb": false,
+	"general_product_information": {
+	  "amazon_sku": "B0DMWR1TQV",
+	  "manufacturer_url": "https://www.pny.com/xlr8-gaming-ddr5-6000-mhz-desktop-memory-kit"
+	}
+  }


### PR DESCRIPTION
- XLR8 Gaming DDR5 5600MHz Desktop Memory Kit CL46
- XLR8 Gaming DDR5 5600MHz Desktop Memory Kit CL36
- XLR8 Gaming DDR5 6000MHz Desktop Memory Kit CL36
- XLR8 Gaming DDR5 6400MHz Desktop Memory Kit CL36