### PR TITLE
Removed color BLACK from properties

### DIFF
--- a/open-db/PCCase/20245fbf-17d0-4fe2-a337-37fa7e51ece8.json
+++ b/open-db/PCCase/20245fbf-17d0-4fe2-a337-37fa7e51ece8.json
@@ -11,8 +11,7 @@
   },
   "form_factor": "ATX Mid Tower",
   "color": [
-    "WHITE",
-    "BLACK"
+    "WHITE"
   ],
   "power_supply": "None",
   "supported_power_supply_form_factors": [],


### PR DESCRIPTION
The "NZXT H9 Elite ATX Mid Tower White with Tempered Glass Side Panel and USB 3.2 Gen 2x2 Type-C, USB 3.2 Gen 1 Type-A" as its name says is "WHITE"! There is not a single cm2 of it that is black and it is annoying that it shows up first when filtering for "BLACK" pc cases.