### PR TITLE
Add Lian Li DK-07X Desk Case

### DIFF
--- a/open-db/PCCase/0a1d75f1-271c-492b-bdae-25bddd4b93ba.json
+++ b/open-db/PCCase/0a1d75f1-271c-492b-bdae-25bddd4b93ba.json
@@ -1,0 +1,33 @@
+{
+  "opendb_id": "0a1d75f1-271c-492b-bdae-25bddd4b93ba",
+  "metadata": {
+    "name": "DK-07X",
+    "manufacturer": "Lian Li",
+    "part_numbers": ["DK-07X"],
+    "series": "DK Series",
+    "variant": "Black"
+  },
+  "supported_motherboard_form_factors": [
+    "E-ATX",
+    "ATX",
+    "Micro ATX",
+    "Mini ITX"
+  ],
+  "form_factor": "Desk",
+  "color": ["Black"],
+  "side_panel": "Tempered Glass",
+  "has_transparent_side_panel": true,
+  "max_video_card_length": 340,
+  "max_cpu_cooler_height": 180,
+  "internal_3_5_bays": 4,
+  "internal_2_5_bays": 4,
+  "expansion_slots": 4,
+  "dimensions": "1480mm x 805mm x 676-1165mm",
+  "front_usb_ports": [
+    "2 x USB 3.1 Type-C",
+    "2 x USB 3.0 Type-A"
+  ],
+  "general_product_information": {
+    "official_url": "https://lian-li.com/product/dk-07x/"
+  }
+}


### PR DESCRIPTION
## Description
Added the Lian Li DK-07X motorized desk case to the database.

## Details
- **Manufacturer:** Lian Li
- **Form Factor:** Desk
- **UUID:** 0a1d75f1-271c-492b-bdae-25bddd4b93ba

## Source
Official Product Page: https://lian-li.com/product/dk-07x/
