### PR TITLE
Corsair 9000d RBG ATX Airflow error

### DIFF
--- a/open-db/PCCase/6900025e-3f60-4c49-88ef-ef514b145890.json
+++ b/open-db/PCCase/6900025e-3f60-4c49-88ef-ef514b145890.json
@@ -10,6 +10,8 @@
     "variant": ""
   },
   "supported_motherboard_form_factors": [
+    "SSI-EEB",
+    "E-ATX",
     "ATX",
     "Micro ATX",
     "Mini-ITX"


### PR DESCRIPTION
Labeling error: The 9000d corsiar official site says it can suport E-ATX and SSI-EEB and BuildCores says it doesm't so i hope i helpet and the problem is fixed because i want tu use that case and i cant because it's showing an error so bye and please fix it soon.