### PR TITLE
[codex] Add Core Ultra 200S Plus CPU entries

### DIFF
--- a/open-db/CPU/42bf3737-1201-40d1-bfd8-7bf606507deb.json
+++ b/open-db/CPU/42bf3737-1201-40d1-bfd8-7bf606507deb.json
@@ -25,7 +25,7 @@
       "model": "Intel Graphics",
       "baseClock": 300,
       "boostClock": 1900,
-      "shaderCount": 4
+      "shaderCount": 512
     },
     "memory": {
       "maxSupport": 256,

--- a/open-db/CPU/42bf3737-1201-40d1-bfd8-7bf606507deb.json
+++ b/open-db/CPU/42bf3737-1201-40d1-bfd8-7bf606507deb.json
@@ -29,9 +29,7 @@
     },
     "memory": {
       "maxSupport": 256,
-      "types": [
-        "DDR5"
-      ],
+      "types": ["DDR5"],
       "channels": 2
     },
     "eccSupport": true,
@@ -44,10 +42,7 @@
   },
   "metadata": {
     "name": "Intel Core Ultra 5 250K Plus",
-    "part_numbers": [
-      "BX80768250K",
-      "Intel Core Ultra 5 250K Plus"
-    ],
+    "part_numbers": ["BX80768250K", "Intel Core Ultra 5 250K Plus"],
     "manufacturer": "Intel",
     "series": "Intel Core Ultra 5 200",
     "variant": "250K Plus",

--- a/open-db/CPU/9b2f142a-6a8f-46bd-a0aa-4b842a20fa18.json
+++ b/open-db/CPU/9b2f142a-6a8f-46bd-a0aa-4b842a20fa18.json
@@ -24,7 +24,8 @@
     "integratedGraphics": {
       "model": "Intel Graphics",
       "baseClock": 300,
-      "boostClock": 2000
+      "boostClock": 2000,
+      "shaderCount": 512
     },
     "memory": {
       "maxSupport": 256,

--- a/open-db/CPU/9b2f142a-6a8f-46bd-a0aa-4b842a20fa18.json
+++ b/open-db/CPU/9b2f142a-6a8f-46bd-a0aa-4b842a20fa18.json
@@ -44,10 +44,7 @@
     "series": "Intel Core Ultra 7 200",
     "variant": "270K Plus",
     "releaseYear": 2026,
-    "part_numbers": [
-      "BX80768270K",
-      "Intel Core Ultra 7 270K Plus"
-    ]
+    "part_numbers": ["BX80768270K", "Intel Core Ultra 7 270K Plus"]
   },
   "series": "Core Ultra 7 200",
   "microarchitecture": "Arrow Lake Refresh",

--- a/open-db/CPU/9b2f142a-6a8f-46bd-a0aa-4b842a20fa18.json
+++ b/open-db/CPU/9b2f142a-6a8f-46bd-a0aa-4b842a20fa18.json
@@ -44,11 +44,14 @@
     "series": "Intel Core Ultra 7 200",
     "variant": "270K Plus",
     "releaseYear": 2026,
-    "part_numbers": ["BX80768270K", "ULTRA 7 270K PLUS"]
+    "part_numbers": [
+      "BX80768270K",
+      "Intel Core Ultra 7 270K Plus"
+    ]
   },
-  "series": "Intel Core Ultra 7 200",
-  "microarchitecture": "Arrow Lake",
-  "coreFamily": "Arrow Lake",
+  "series": "Core Ultra 7 200",
+  "microarchitecture": "Arrow Lake Refresh",
+  "coreFamily": "Lion Cove / Skymont",
   "socket": "LGA 1851",
   "general_product_information": {
     "amazon_sku": "B0GMLJCBBM",

--- a/open-db/CPU/a0415d5e-2c30-4133-873e-92a5f37ae9da.json
+++ b/open-db/CPU/a0415d5e-2c30-4133-873e-92a5f37ae9da.json
@@ -1,5 +1,5 @@
 {
-  "opendb_id": "42bf3737-1201-40d1-bfd8-7bf606507deb",
+  "opendb_id": "a0415d5e-2c30-4133-873e-92a5f37ae9da",
   "cores": {
     "total": 18,
     "performance": 6,
@@ -22,10 +22,7 @@
   },
   "specifications": {
     "integratedGraphics": {
-      "model": "Intel Graphics",
-      "baseClock": 300,
-      "boostClock": 1900,
-      "shaderCount": 4
+      "model": "None"
     },
     "memory": {
       "maxSupport": 256,
@@ -34,7 +31,7 @@
       ],
       "channels": 2
     },
-    "eccSupport": true,
+    "eccSupport": false,
     "includesCooler": false,
     "packaging": "Boxed",
     "simultaneousMultithreading": false,
@@ -43,14 +40,14 @@
     "lithography": "TSMC N3B"
   },
   "metadata": {
-    "name": "Intel Core Ultra 5 250K Plus",
+    "name": "Intel Core Ultra 5 250KF Plus",
     "part_numbers": [
-      "BX80768250K",
-      "Intel Core Ultra 5 250K Plus"
+      "BX80768250KF",
+      "Intel Core Ultra 5 250KF Plus"
     ],
     "manufacturer": "Intel",
     "series": "Intel Core Ultra 5 200",
-    "variant": "250K Plus",
+    "variant": "250KF Plus",
     "releaseYear": 2026
   },
   "series": "Core Ultra 5 200",
@@ -58,7 +55,8 @@
   "coreFamily": "Lion Cove / Skymont",
   "socket": "LGA 1851",
   "general_product_information": {
-    "newegg_sku": "N82E16819118629",
-    "bestbuy_sku": 12486935
+    "newegg_sku": "N82E16819118630",
+    "bestbuy_sku": 12527151,
+    "walmart_sku": 19949371519
   }
 }

--- a/open-db/CPU/a0415d5e-2c30-4133-873e-92a5f37ae9da.json
+++ b/open-db/CPU/a0415d5e-2c30-4133-873e-92a5f37ae9da.json
@@ -26,9 +26,7 @@
     },
     "memory": {
       "maxSupport": 256,
-      "types": [
-        "DDR5"
-      ],
+      "types": ["DDR5"],
       "channels": 2
     },
     "eccSupport": false,
@@ -41,10 +39,7 @@
   },
   "metadata": {
     "name": "Intel Core Ultra 5 250KF Plus",
-    "part_numbers": [
-      "BX80768250KF",
-      "Intel Core Ultra 5 250KF Plus"
-    ],
+    "part_numbers": ["BX80768250KF", "Intel Core Ultra 5 250KF Plus"],
     "manufacturer": "Intel",
     "series": "Intel Core Ultra 5 200",
     "variant": "250KF Plus",


### PR DESCRIPTION
## What changed

- completed the existing Core Ultra 5 250K Plus entry with Intel launch specs, boxed part number metadata, and retailer SKUs
- normalized the existing Core Ultra 7 270K Plus entry to match the refreshed Arrow Lake naming and metadata conventions
- added a new Core Ultra 5 250KF Plus CPU entry with Intel specs and retailer SKUs

## Why

- `main` already had partial Core Ultra 200S Plus coverage, but the lineup was incomplete and one of the existing Plus entries was missing key product metadata
- downstream BuildCores consumers benefit from having the boxed retail SKUs and refreshed Intel CPU specs in a consistent shape

## Impact

- improves coverage for Intel desktop Core Ultra 200S Plus CPUs in the open database
- makes retailer-based product matching easier for the new boxed Plus refresh parts

## Validation

- `./scripts/validate.sh open-db/CPU/42bf3737-1201-40d1-bfd8-7bf606507deb.json open-db/CPU/9b2f142a-6a8f-46bd-a0aa-4b842a20fa18.json open-db/CPU/a0415d5e-2c30-4133-873e-92a5f37ae9da.json`
