### PR TITLE
fix fan_size and fan_quantity on ARCTIC Liquid Freezer II Water 360mm

### DIFF
--- a/open-db/CPUCooler/eb66ae81-da3c-4a26-9828-c69747408d26.json
+++ b/open-db/CPUCooler/eb66ae81-da3c-4a26-9828-c69747408d26.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 360,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 3,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B07WNJCVNW",


### PR DESCRIPTION
Corrected fan_quantity and fan_size for the ARCTIC Liquid Freezer II 360 (ACFRE00068B). 
Manufacturer spec lists „ARCTIC P12 120 mm Fan x3" → fan_size=120, fan_quantity=3.
Sources:

https://www.arctic.de/en/Liquid-Freezer-II-360/ACFRE00068B (Technical specifications → Fan)