### PR TITLE
Adding fan specs for several ARCTIC Liquid Freezer variants

### DIFF
--- a/open-db/CPUCooler/072f22a9-a383-4197-8871-820b1d0fc2db.json
+++ b/open-db/CPUCooler/072f22a9-a383-4197-8871-820b1d0fc2db.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 280,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 140,
+  "fan_quantity": 2,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B099RTZX79",

--- a/open-db/CPUCooler/1b6e81aa-ed80-450f-90f7-4bc816db2cdf.json
+++ b/open-db/CPUCooler/1b6e81aa-ed80-450f-90f7-4bc816db2cdf.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 120,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 1,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B07WRCY747",

--- a/open-db/CPUCooler/2d804182-5f37-4153-a28d-3134f82eb148.json
+++ b/open-db/CPUCooler/2d804182-5f37-4153-a28d-3134f82eb148.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 240,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 2,
   "lighting": [],
   "general_product_information": {}
 }

--- a/open-db/CPUCooler/3e1bcc6c-0d0b-45df-b858-4a17d49dd56a.json
+++ b/open-db/CPUCooler/3e1bcc6c-0d0b-45df-b858-4a17d49dd56a.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 240,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 2,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B08WRJ5MQW",

--- a/open-db/CPUCooler/5af1ae6a-5972-472d-9e1b-b1e9487dc127.json
+++ b/open-db/CPUCooler/5af1ae6a-5972-472d-9e1b-b1e9487dc127.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 360,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 3,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B08WRWNNZ9",

--- a/open-db/CPUCooler/69232164-b276-498a-b06f-cc644e04a85f.json
+++ b/open-db/CPUCooler/69232164-b276-498a-b06f-cc644e04a85f.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 360,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 3,
   "lighting": [],
   "general_product_information": {}
 }

--- a/open-db/CPUCooler/95d03024-f9eb-4f36-b234-f2aa6783993c.json
+++ b/open-db/CPUCooler/95d03024-f9eb-4f36-b234-f2aa6783993c.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 360,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 3,
   "lighting": [],
   "general_product_information": {}
 }

--- a/open-db/CPUCooler/a93a09a1-b617-4d06-8b21-dd4224bc1d81.json
+++ b/open-db/CPUCooler/a93a09a1-b617-4d06-8b21-dd4224bc1d81.json
@@ -33,8 +33,8 @@
   "water_cooled": true,
   "radiator_size": 240,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 2,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B07WSDLRVP",

--- a/open-db/CPUCooler/b5e24305-89eb-419c-aeef-1f6895646b3f.json
+++ b/open-db/CPUCooler/b5e24305-89eb-419c-aeef-1f6895646b3f.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 280,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 140,
+  "fan_quantity": 2,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B09BNJB2FP"

--- a/open-db/CPUCooler/c33b509c-dba0-420b-8bb6-654435a8e851.json
+++ b/open-db/CPUCooler/c33b509c-dba0-420b-8bb6-654435a8e851.json
@@ -33,8 +33,8 @@
   "water_cooled": true,
   "radiator_size": 280,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 140,
+  "fan_quantity": 2,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B07WP6M7P7",

--- a/open-db/CPUCooler/da9dc84b-961b-4da3-beaf-8419a834a3ab.json
+++ b/open-db/CPUCooler/da9dc84b-961b-4da3-beaf-8419a834a3ab.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 420,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 140,
+  "fan_quantity": 3,
   "lighting": [],
   "general_product_information": {}
 }

--- a/open-db/CPUCooler/f35a4968-798c-4d44-8377-8ab94b5e06f9.json
+++ b/open-db/CPUCooler/f35a4968-798c-4d44-8377-8ab94b5e06f9.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 240,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 120,
+  "fan_quantity": 2,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B08WRJ8LP2",

--- a/open-db/CPUCooler/fa1d8925-963e-4bc5-85b7-f7c6ab1548d7.json
+++ b/open-db/CPUCooler/fa1d8925-963e-4bc5-85b7-f7c6ab1548d7.json
@@ -30,8 +30,8 @@
   "water_cooled": true,
   "radiator_size": 420,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
+  "fan_size": 140,
+  "fan_quantity": 3,
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B09CKW8LJ6",


### PR DESCRIPTION
Filled missing fan_size/fan_quantity for several Liquid Freezer II variants

Examples:
Liquid Freezer II 240: https://www.arctic.de/en/Liquid-Freezer-II-240/ACFRE00046B
Liquid Freezer II 240 A-RGB: https://www.arctic.de/en/Liquid-Freezer-II-240-A-RGB/ACFRE00093A

At Technical specifications & manual -> General Specifications