### PR TITLE
Deleting wrong "part_numbers" from TeamGroup T-Force DELTA RGB 64GB (2x32GB) DDR4 3000 CL16 Black

### DIFF
--- a/open-db/RAM/de9f2218-f94c-4f80-a43b-bd7170ac9615.json
+++ b/open-db/RAM/de9f2218-f94c-4f80-a43b-bd7170ac9615.json
@@ -7,7 +7,7 @@
   "metadata": {
     "name": "TeamGroup T-Force DELTA RGB 64GB (2x32GB) DDR4 3000 CL16 Black",
     "manufacturer": "TEAMGROUP",
-    "part_numbers": ["TF3D464G3000HC16CDC01", "TF3D416G3200HC16FDC01"],
+    "part_numbers": ["TF3D464G3000HC16CDC01"],
     "series": "T-Force",
     "variant": "3000 CL16",
     "manufacturer_color": "Black",


### PR DESCRIPTION
TF3D416G3200HC16FDC01 is 16GB(2x8GB):

https://www.teamgroupinc.com/en/product-detail/memory/T-FORCE/delta-rgb-ddr4-black/delta-rgb-ddr4-black-TF3D416G3200HC16CDC01/

<img width="1096" height="60" alt="image" src="https://github.com/user-attachments/assets/481ca3c3-1cd3-4c1b-b8da-8ab65f92efa0" />

Fixes #153 