### PR TITLE
Fix ASRock B850I Lightning WiFi PCIe generation

### DIFF
--- a/open-db/Motherboard/5249e76b-f3d3-4224-890b-b5c072c39333.json
+++ b/open-db/Motherboard/5249e76b-f3d3-4224-890b-b5c072c39333.json
@@ -46,7 +46,7 @@
   "color": ["BLACK"],
   "pcie_slots": [
     {
-      "gen": "4.0",
+      "gen": "5.0",
       "quantity": 1,
       "lanes": 16
     }


### PR DESCRIPTION
## Summary
- update ASRock B850I Lightning WiFi PCIe x16 slot from PCIe 4.0 to PCIe 5.0

## Validation
- jq empty on changed file
- npx ajv-cli against Motherboard schema