### PR TITLE
Fix several component spec issues

### DIFF
--- a/open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json
+++ b/open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json
@@ -42,11 +42,11 @@
     "ppt": 253
   },
   "metadata": {
-    "name": "Intel Core i9-14900KS",
+    "name": "Intel Core i9-14900K",
     "manufacturer": "Intel",
     "part_numbers": ["BX8071514900K"],
     "series": "Core i9 14000",
-    "variant": "14900KS",
+    "variant": "14900K",
     "releaseYear": 2023
   },
   "series": "Core i9 14000",

--- a/open-db/Monitor/27f40dcb-6285-48b4-8a33-e8ffa242dee9.json
+++ b/open-db/Monitor/27f40dcb-6285-48b4-8a33-e8ffa242dee9.json
@@ -7,7 +7,7 @@
   "metadata": {
     "name": "MSI MAG 274QP QD-OLED X24",
     "manufacturer": "MSI",
-    "part_numbers": ["MAG 274QP QD-OLED X24", "MAG 274CF X24"],
+    "part_numbers": ["MAG 274QP QD-OLED X24"],
     "series": "MAG",
     "variant": "274QP QD-OLED X24",
     "last_manually_spec_verified_at": "2026-02-21T11:03:25.282Z"
@@ -15,7 +15,7 @@
   "screen_size": 26.5,
   "refresh_rate": 240,
   "panel_type": "QD-OLED",
-  "response_time": 240,
+  "response_time": 0.03,
   "color": ["BLACK"],
   "viewing_angle": "178° H x 178° V",
   "aspect_ratio": "16:9",
@@ -26,7 +26,6 @@
   "lighting": [],
   "general_product_information": {
     "newegg_sku": "N82E16824475541",
-    "bestbuy_sku": 12008069,
     "walmart_sku": 19020672159,
     "manufacturer_url": "https://www.msi.com/Monitor/MAG-274QP-QD-OLED-X24"
   }

--- a/open-db/PSU/10ae69ee-583a-49ba-ac4a-e6972a7bd8f4.json
+++ b/open-db/PSU/10ae69ee-583a-49ba-ac4a-e6972a7bd8f4.json
@@ -30,7 +30,6 @@
   "general_product_information": {
     "amazon_sku": "B0CC8H91K8",
     "newegg_sku": "1HU-004H-000T0",
-    "walmart_sku": 5050122769,
     "manufacturer_url": "https://www.bequiet.com/en/powersupply/4653"
   }
 }


### PR DESCRIPTION
Fixes several small verified component data issues:

- correct Intel Core i9-14900K mislabeled as 14900KS
- fix MSI MAG 274QP QD-OLED X24 response time and stray 274CF part number
- remove bad Walmart SKU from be quiet! Straight Power 12 750W
- correct ASRock B850I Lightning WiFi PCIe x16 slot to PCIe 5.0

Validation: jq empty; npx ajv for changed JSON files.