### PR TITLE
Fix storage records from issue reports

### DIFF
--- a/open-db/Storage/4f433fb7-0e34-4057-bec3-8b8e673ad3b6.json
+++ b/open-db/Storage/4f433fb7-0e34-4057-bec3-8b8e673ad3b6.json
@@ -3,9 +3,10 @@
   "metadata": {
     "name": "Crucial P310 4TB SSD M.2-2280 PCIe 4.0 X4 NVMe",
     "manufacturer": "Crucial",
-    "part_numbers": ["CT4000P310SSD8", "S101Q", "CT4000P310SSD801"],
+    "part_numbers": ["CT4000P310SSD8", "CT4000P310SSD801"],
     "series": "P310",
-    "variant": "4000GB"
+    "variant": "4000GB",
+    "last_manually_spec_verified_at": "2026-07-05T09:22:00.000Z"
   },
   "capacity": 4000,
   "type": "SSD",
@@ -18,6 +19,7 @@
   "general_product_information": {
     "newegg_sku": "N82E16820156436",
     "bestbuy_sku": 6594263,
-    "walmart_sku": 16300169783
+    "walmart_sku": 16300169783,
+    "manufacturer_url": "https://www.crucial.com/ssd/p310/ct4000p310ssd8/ct25204422"
   }
 }

--- a/open-db/Storage/6721bfca-b87a-43de-9ee6-b19a5aabe959.json
+++ b/open-db/Storage/6721bfca-b87a-43de-9ee6-b19a5aabe959.json
@@ -5,7 +5,8 @@
     "manufacturer": "Lexar",
     "part_numbers": ["LEQ790X002T-RNNNG"],
     "series": "EQ790",
-    "variant": "2000GB"
+    "variant": "2000GB",
+    "last_manually_spec_verified_at": "2026-07-05T09:22:00.000Z"
   },
   "capacity": 2000,
   "type": "SSD",
@@ -15,5 +16,8 @@
   "nvme": true,
   "storage_type": "SSD",
   "lighting": [],
-  "general_product_information": {}
+  "general_product_information": {
+    "amazon_sku": "B0DNMDSKDT",
+    "manufacturer_url": "https://resources.lexar.com/download/2171/document/14415/lexar_eq790-ssd_setup-sheet_1223.pdf"
+  }
 }

--- a/open-db/Storage/db5c18c8-bd35-4b10-8817-6f95e1a0782e.json
+++ b/open-db/Storage/db5c18c8-bd35-4b10-8817-6f95e1a0782e.json
@@ -1,11 +1,12 @@
 {
   "opendb_id": "db5c18c8-bd35-4b10-8817-6f95e1a0782e",
   "metadata": {
-    "name": "Inland Gaming Performance Plus 8TB SSD M.2-2280 PCIe 4.0 X4 NVMe",
+    "name": "Inland Performance Plus 8TB SSD M.2-2280 PCIe 4.0 X4 NVMe",
     "manufacturer": "Inland",
     "part_numbers": ["8TB PER SSD PS5", "618996750429", "7e32a157-8978-444e-ab6e-0292559aad3f"],
-    "series": "Gaming",
-    "variant": "8000GB"
+    "series": "Performance Plus",
+    "variant": "8000GB Heatsink",
+    "last_manually_spec_verified_at": "2026-07-05T09:22:00.000Z"
   },
   "capacity": 8000,
   "type": "SSD",
@@ -15,6 +16,7 @@
   "storage_type": "SSD",
   "lighting": [],
   "general_product_information": {
-    "amazon_sku": "B0BG25JP68"
+    "amazon_sku": "B0BG25JP68",
+    "manufacturer_url": "https://www.microcenter.com/product/651927/inland-performance-plus-8tb-3d-tlc-nand-pcie-gen-4-x4-nvme-m2-internal-ssd"
   }
 }


### PR DESCRIPTION
Fixes storage issue reports:

- Crucial P310 4TB: remove incorrect part number and add official URL
- Inland Performance Plus 8TB: correct series/name and heatsink variant
- Lexar EQ790 2TB: add verified Amazon ASIN and setup sheet URL

Validation: jq empty; npx ajv for changed Storage JSON files.