### PR TITLE
Add Valve Index VR headset

### DIFF
--- a/open-db/VRHeadset/d7700e91-ab89-4b53-9bf7-065f053161c8.json
+++ b/open-db/VRHeadset/d7700e91-ab89-4b53-9bf7-065f053161c8.json
@@ -1,0 +1,14 @@
+{
+  "opendb_id": "d7700e91-ab89-4b53-9bf7-065f053161c8",
+  "metadata": {
+    "name": "Valve Index Headset",
+    "manufacturer": "Valve",
+    "series": "Index",
+    "variant": "Headset",
+    "releaseYear": 2019,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://store.steampowered.com/valveindex"
+  }
+}


### PR DESCRIPTION
Adds Valve Index as a VR/XR headset record.

Validation: jq empty; npx ajv for VRHeadset JSON.