### PR TITLE
Add Keychron K5 Max ISO variants

### DIFF
--- a/open-db/Keyboard/0fdfa894-c6db-42e5-ae5d-01eeafca35ce.json
+++ b/open-db/Keyboard/0fdfa894-c6db-42e5-ae5d-01eeafca35ce.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "0fdfa894-c6db-42e5-ae5d-01eeafca35ce",
+  "switch": "Low Profile Gateron Mechanical Brown",
+  "switch_type": "Tactile",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336307801"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout UK Brown",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H3-UK"],
+    "series": "K5 Max",
+    "variant": "UK-ISO / Low Profile Gateron Mechanical Brown",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}

--- a/open-db/Keyboard/3495820b-3656-47eb-915d-98cd809971e5.json
+++ b/open-db/Keyboard/3495820b-3656-47eb-915d-98cd809971e5.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "3495820b-3656-47eb-915d-98cd809971e5",
+  "switch": "Low Profile Gateron Mechanical Brown",
+  "switch_type": "Tactile",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336438873"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout Swiss Brown",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H3-SW"],
+    "series": "K5 Max",
+    "variant": "Swiss-ISO / Low Profile Gateron Mechanical Brown",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}

--- a/open-db/Keyboard/39a5d814-ecd4-423b-bc23-18f3a5f60514.json
+++ b/open-db/Keyboard/39a5d814-ecd4-423b-bc23-18f3a5f60514.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "39a5d814-ecd4-423b-bc23-18f3a5f60514",
+  "switch": "Low Profile Gateron Mechanical Brown",
+  "switch_type": "Tactile",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336504409"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout Nordic Brown",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H3-BO"],
+    "series": "K5 Max",
+    "variant": "Nordic-ISO / Low Profile Gateron Mechanical Brown",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}

--- a/open-db/Keyboard/3b3b1fb8-0842-41b7-9eb4-0a1f22f3c8b0.json
+++ b/open-db/Keyboard/3b3b1fb8-0842-41b7-9eb4-0a1f22f3c8b0.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "3b3b1fb8-0842-41b7-9eb4-0a1f22f3c8b0",
+  "switch": "Low Profile Gateron Mechanical Red",
+  "switch_type": "Linear",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336340569"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout German Red",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H1-DE"],
+    "series": "K5 Max",
+    "variant": "DE-ISO / Low Profile Gateron Mechanical Red",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}

--- a/open-db/Keyboard/6f8b31fe-05fc-4058-971c-20d02e16bac7.json
+++ b/open-db/Keyboard/6f8b31fe-05fc-4058-971c-20d02e16bac7.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "6f8b31fe-05fc-4058-971c-20d02e16bac7",
+  "switch": "Low Profile Gateron Mechanical Red",
+  "switch_type": "Linear",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336406105"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout Swiss Red",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H1-SW"],
+    "series": "K5 Max",
+    "variant": "Swiss-ISO / Low Profile Gateron Mechanical Red",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}

--- a/open-db/Keyboard/8b68c670-eb7e-4ee0-bf6e-2bd84420ff72.json
+++ b/open-db/Keyboard/8b68c670-eb7e-4ee0-bf6e-2bd84420ff72.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "8b68c670-eb7e-4ee0-bf6e-2bd84420ff72",
+  "switch": "Low Profile Gateron Mechanical Brown",
+  "switch_type": "Tactile",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336373337"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout German Brown",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H3-DE"],
+    "series": "K5 Max",
+    "variant": "DE-ISO / Low Profile Gateron Mechanical Brown",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}

--- a/open-db/Keyboard/9681e092-9c04-448f-a3fb-e64b3cad77a2.json
+++ b/open-db/Keyboard/9681e092-9c04-448f-a3fb-e64b3cad77a2.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "9681e092-9c04-448f-a3fb-e64b3cad77a2",
+  "switch": "Low Profile Gateron Mechanical Red",
+  "switch_type": "Linear",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336471641"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout Nordic Red",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H1-BO"],
+    "series": "K5 Max",
+    "variant": "Nordic-ISO / Low Profile Gateron Mechanical Red",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}

--- a/open-db/Keyboard/bb71f71a-0dd4-47fe-a703-e3b7cbb96a9c.json
+++ b/open-db/Keyboard/bb71f71a-0dd4-47fe-a703-e3b7cbb96a9c.json
@@ -1,0 +1,26 @@
+{
+  "opendb_id": "bb71f71a-0dd4-47fe-a703-e3b7cbb96a9c",
+  "switch": "Low Profile Gateron Mechanical Red",
+  "switch_type": "Linear",
+  "size": "Full Size",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": ["RGB"],
+  "features": ["Low Profile"],
+  "connectivity": ["Wired USB-C", "Wireless 2.4GHz", "Bluetooth"],
+  "keycap_material": "Double-shot PBT",
+  "polling_rate": 1000,
+  "battery_capacity": 2000,
+  "general_product_information": {
+    "manufacturer_url": "https://www.keychron.com/products/keychron-k5-max-qmk-wireless-custom-mechanical-keyboard-iso-layout-collection?variant=41705336275033"
+  },
+  "metadata": {
+    "name": "Keychron K5 Max QMK Wireless Custom Mechanical Keyboard ISO Layout UK Red",
+    "manufacturer": "Keychron",
+    "part_numbers": ["K5M-H1-UK"],
+    "series": "K5 Max",
+    "variant": "UK-ISO / Low Profile Gateron Mechanical Red",
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-07-05T09:21:00Z"
+  }
+}


### PR DESCRIPTION
Adds Keychron K5 Max ISO collection variants for UK, German, Swiss, and Nordic layouts with Red and Brown switch options.

Validation: jq empty; npx ajv for changed Keyboard JSON files.