### PR TITLE
Fix Intel Core i9-14900K label

### DIFF
--- a/open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json
+++ b/open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json
@@ -42,11 +42,11 @@
     "ppt": 253
   },
   "metadata": {
-    "name": "Intel Core i9-14900KS",
+    "name": "Intel Core i9-14900K",
     "manufacturer": "Intel",
     "part_numbers": ["BX8071514900K"],
     "series": "Core i9 14000",
-    "variant": "14900KS",
+    "variant": "14900K",
     "releaseYear": 2023
   },
   "series": "Core i9 14000",


### PR DESCRIPTION
Fixes #227.\n\nChanges:\n- Rename mislabeled Core i9-14900K record from 14900KS to 14900K\n- Correct the metadata variant to match the existing 14900K part number\n\nValidation:\n- jq empty open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json\n- npx ajv-cli validate --strict=false -s schemas/CPU.schema.json -d open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json