### PR TITLE
Fix MSI RTX 5080 Gaming Trio White metadata

### DIFF
--- a/open-db/GPU/4a7c4013-3107-4db3-aca8-9cbeec3d01fd.json
+++ b/open-db/GPU/4a7c4013-3107-4db3-aca8-9cbeec3d01fd.json
@@ -9,12 +9,12 @@
   },
   "metadata": {
     "name": "MSI GeForce RTX 5080 16G GAMING TRIO WHITE",
-    "manufacturer": "NVIDIA",
+    "manufacturer": "MSI",
     "releaseYear": 2025,
     "manufacturer_color": "White",
-    "part_numbers": [],
-    "series": "GAMING",
-    "variant": "TRIO"
+    "part_numbers": ["G5080-16GTW", "RTX 5080 16G GAMING TRIO WHITE"],
+    "series": "GAMING TRIO",
+    "variant": ""
   },
   "chipset_manufacturer": "NVIDIA",
   "chipset": "GeForce RTX 5080",


### PR DESCRIPTION
Fixes issue #229 by correcting the MSI GeForce RTX 5080 16G GAMING TRIO WHITE record metadata.

Changes:
- set board manufacturer to MSI instead of NVIDIA
- add official MSI part numbers
- normalize series/variant for the non-OC white Gaming Trio record

Validation: jq empty; npx ajv against GPU schema.