### PR TITLE
Update Lian Li SL LCD and HydroShift records

### DIFF
--- a/open-db/CPUCooler/36577d52-229d-453a-ac3b-fc9ef9b41bc7.json
+++ b/open-db/CPUCooler/36577d52-229d-453a-ac3b-fc9ef9b41bc7.json
@@ -34,8 +34,8 @@
   "fanless": false,
   "fan_size": 120,
   "fan_quantity": 3,
-  "lighting": ["Display"],
+  "lighting": ["Display", "ARGB"],
   "general_product_information": {
-    "manufacturer_url": "https://lian-li.com/product/hydroshift-ii/"
+    "manufacturer_url": "https://lian-li.com/product/hydroshift-ii-lcd-c/"
   }
 }

--- a/open-db/CPUCooler/36577d52-229d-453a-ac3b-fc9ef9b41bc7.json
+++ b/open-db/CPUCooler/36577d52-229d-453a-ac3b-fc9ef9b41bc7.json
@@ -7,8 +7,10 @@
       "GHS2LCD36TW                                                    G89.GHS2LCD36TW.00"
     ],
     "series": "Hydroshift",
-    "variant": "White",
-    "releaseYear": null
+    "variant": "LCD-C TL",
+    "releaseYear": 2025,
+    "manufacturer_color": "White",
+    "last_manually_spec_verified_at": "2026-07-05T09:33:00.000Z"
   },
   "min_fan_rpm": 200,
   "max_fan_rpm": 2600,
@@ -30,8 +32,10 @@
   "water_cooled": true,
   "radiator_size": 360,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
-  "lighting": [],
-  "general_product_information": {}
+  "fan_size": 120,
+  "fan_quantity": 3,
+  "lighting": ["Display"],
+  "general_product_information": {
+    "manufacturer_url": "https://lian-li.com/product/hydroshift-ii/"
+  }
 }

--- a/open-db/CaseFan/a408a83b-21c1-4270-a581-02d83efd46f0.json
+++ b/open-db/CaseFan/a408a83b-21c1-4270-a581-02d83efd46f0.json
@@ -4,9 +4,10 @@
     "name": "Lian Li UNI FAN SL Wireless LCD Reverse 120mm 51.45 CFM Addressable RGB PWM White",
     "manufacturer": "Lian Li",
     "series": "UNI SL Wireless LCD",
-    "variant": "120mm White",
+    "variant": "",
     "manufacturer_color": "White",
-    "part_numbers": []
+    "part_numbers": ["12RSLLCD1W1W"],
+    "last_manually_spec_verified_at": "2026-07-05T09:33:00.000Z"
   },
   "size": 120,
   "color": ["WHITE"],
@@ -20,5 +21,10 @@
   "static_pressure": 2.1,
   "flow_direction": "Reverse",
   "isOEM": false,
-  "general_product_information": {}
+  "general_product_information": {
+    "bestbuy_sku": 11076616,
+    "walmart_sku": 14404574481,
+    "adorama_sku": "LI12RSLLCD1W",
+    "manufacturer_url": "https://lian-li.com/product/uni-fan-sl-wireless/"
+  }
 }

--- a/open-db/CaseFan/a408a83b-21c1-4270-a581-02d83efd46f0.json
+++ b/open-db/CaseFan/a408a83b-21c1-4270-a581-02d83efd46f0.json
@@ -4,7 +4,7 @@
     "name": "Lian Li UNI FAN SL Wireless LCD Reverse 120mm 51.45 CFM Addressable RGB PWM White",
     "manufacturer": "Lian Li",
     "series": "UNI SL Wireless LCD",
-    "variant": "",
+    "variant": "Reverse",
     "manufacturer_color": "White",
     "part_numbers": ["12RSLLCD1W1W"],
     "last_manually_spec_verified_at": "2026-07-05T09:33:00.000Z"

--- a/open-db/CaseFan/f198d090-58d7-48c8-9ced-043681b08f81.json
+++ b/open-db/CaseFan/f198d090-58d7-48c8-9ced-043681b08f81.json
@@ -4,9 +4,10 @@
     "name": "Lian Li UNI FAN SL Wireless LCD 120mm Black Reverse Addressable RGB PWM",
     "manufacturer": "Lian Li",
     "series": "UNI SL Wireless LCD",
-    "variant": "120mm Black",
+    "variant": "",
     "manufacturer_color": "Black",
-    "part_numbers": []
+    "part_numbers": ["12RSLLCD1W1B"],
+    "last_manually_spec_verified_at": "2026-07-05T09:33:00.000Z"
   },
   "size": 120,
   "color": ["BLACK"],
@@ -19,6 +20,8 @@
   "static_pressure": 2.6,
   "flow_direction": "Reverse",
   "isOEM": false,
-  "lighting": [],
-  "general_product_information": {}
+  "lighting": ["ARGB"],
+  "general_product_information": {
+    "manufacturer_url": "https://lian-li.com/product/uni-fan-sl-wireless/"
+  }
 }

--- a/open-db/CaseFan/f198d090-58d7-48c8-9ced-043681b08f81.json
+++ b/open-db/CaseFan/f198d090-58d7-48c8-9ced-043681b08f81.json
@@ -4,7 +4,7 @@
     "name": "Lian Li UNI FAN SL Wireless LCD 120mm Black Reverse Addressable RGB PWM",
     "manufacturer": "Lian Li",
     "series": "UNI SL Wireless LCD",
-    "variant": "",
+    "variant": "Reverse",
     "manufacturer_color": "Black",
     "part_numbers": ["12RSLLCD1W1B"],
     "last_manually_spec_verified_at": "2026-07-05T09:33:00.000Z"


### PR DESCRIPTION
Fixes Lian Li issue reports #230 and #231.

Changes:
- add part numbers, official URL, and available supported retailer SKUs for SL Wireless LCD reverse single-pack fans
- update HydroShift II LCD-C TL 360 White metadata, fan count, display lighting, and official URL

Validation: jq empty; npx ajv against CaseFan and CPUCooler schemas.