### PR TITLE
Update Corsair 1000D motherboard and I/O specs

### DIFF
--- a/open-db/PCCase/12ad3d96-45d1-4e87-b7f0-8a750dd45e70.json
+++ b/open-db/PCCase/12ad3d96-45d1-4e87-b7f0-8a750dd45e70.json
@@ -7,7 +7,7 @@
     "series": "Obsidian",
     "variant": ""
   },
-  "supported_motherboard_form_factors": ["ATX", "Micro ATX", "Mini-ITX"],
+  "supported_motherboard_form_factors": ["ATX", "Micro ATX", "Mini-ITX", "EATX", "SSI EEB"],
   "form_factor": "ATX Full Tower",
   "color": ["BLACK"],
   "power_supply": "None",
@@ -22,12 +22,13 @@
   "dimensions": "698 x 307 x 696",
   "volume": 149.143,
   "weight": null,
-  "supported_power_supply_form_factors": [],
-  "front_usb_ports": [],
+  "supported_power_supply_form_factors": ["ATX"],
+  "front_usb_ports": ["2x USB 3.2 Gen 2 Type-C", "4x USB 3.2 Gen 1 Type-A"],
   "lighting": [],
   "general_product_information": {
     "amazon_sku": "B07BQG4TM3",
     "newegg_sku": "N82E16811139123",
-    "walmart_sku": 147704165
+    "walmart_sku": 147704165,
+    "manufacturer_url": "https://www.corsair.com/us/en/p/pc-cases/cc-9011148-ww/obsidian-series-1000d-super-tower-case-cc-9011148-ww"
   }
 }

--- a/open-db/PCCase/12ad3d96-45d1-4e87-b7f0-8a750dd45e70.json
+++ b/open-db/PCCase/12ad3d96-45d1-4e87-b7f0-8a750dd45e70.json
@@ -22,7 +22,7 @@
   "dimensions": "698 x 307 x 696",
   "volume": 149.143,
   "weight": null,
-  "supported_power_supply_form_factors": ["ATX"],
+  "supported_power_supply_form_factors": ["ATX", "SFX"],
   "front_usb_ports": ["2x USB 3.2 Gen 2 Type-C", "4x USB 3.2 Gen 1 Type-A"],
   "lighting": [],
   "general_product_information": {


### PR DESCRIPTION
## Summary
- add EATX and SSI EEB motherboard support to the Corsair Obsidian 1000D
- fill ATX PSU support and front USB ports from Corsair tech specs
- add the official manufacturer URL

Fixes #204

## Validation
- `PATH="$tmp/node_modules/.bin:$PATH" ./scripts/validate.sh open-db/PCCase/12ad3d96-45d1-4e87-b7f0-8a750dd45e70.json`