### PR TITLE
Fix mislabeled Core i9-14900K record

### DIFF
--- a/open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json
+++ b/open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json
@@ -42,11 +42,11 @@
     "ppt": 253
   },
   "metadata": {
-    "name": "Intel Core i9-14900KS",
+    "name": "Intel Core i9-14900K",
     "manufacturer": "Intel",
     "part_numbers": ["BX8071514900K"],
     "series": "Core i9 14000",
-    "variant": "14900KS",
+    "variant": "14900K",
     "releaseYear": 2023
   },
   "series": "Core i9 14000",


### PR DESCRIPTION
## Summary
- rename the mislabeled Core i9-14900K record from 14900KS to 14900K
- align metadata.variant with the BX8071514900K part number and Intel product page

Fixes #227

## Validation
- `PATH="$tmp/node_modules/.bin:$PATH" ./scripts/validate.sh open-db/CPU/e80823a0-6dd5-47d0-b69b-852e92acf964.json`