### PR TITLE
Fix iStarUSA TC-1200PD8G retailer data

### DIFF
--- a/open-db/PSU/f9595c5b-49ff-4e98-a2ec-cc8d4dd96094.json
+++ b/open-db/PSU/f9595c5b-49ff-4e98-a2ec-cc8d4dd96094.json
@@ -12,9 +12,9 @@
   "metadata": {
     "name": "iStarUSA TC-1200PD8G Gray ATX 1200W Fully Modular",
     "manufacturer": "iStarUSA",
-    "part_numbers": ["TC-1200PD8G", "Newegg_Delete"],
+    "part_numbers": ["TC-1200PD8G"],
     "series": "TC-1200PD8G",
-    "variant": "1200W "
+    "variant": "1200W"
   },
   "wattage": 1200,
   "form_factor": "ATX",
@@ -25,7 +25,7 @@
   "fanless": false,
   "lighting": [],
   "general_product_information": {
-    "amazon_sku": "B0GY91WWHP",
-    "newegg_sku": "0Y3-008J-00002"
+    "newegg_sku": "0Y3-008J-00002",
+    "manufacturer_url": "https://istarusa.com/assets/pdf/datasheet/TC-1200PD8G_specsheet.pdf"
   }
 }


### PR DESCRIPTION
## Summary
- remove the incorrect Amazon SKU from the iStarUSA TC-1200PD8G PSU
- drop the placeholder Newegg_Delete part number and trim the variant
- add the manufacturer datasheet URL while keeping the matching Newegg product SKU

Fixes #199

## Validation
- `PATH="$tmp/node_modules/.bin:$PATH" ./scripts/validate.sh open-db/PSU/f9595c5b-49ff-4e98-a2ec-cc8d4dd96094.json`