### PR TITLE
Remove bad Walmart SKU from Straight Power 12

### DIFF
--- a/open-db/PSU/10ae69ee-583a-49ba-ac4a-e6972a7bd8f4.json
+++ b/open-db/PSU/10ae69ee-583a-49ba-ac4a-e6972a7bd8f4.json
@@ -30,7 +30,6 @@
   "general_product_information": {
     "amazon_sku": "B0CC8H91K8",
     "newegg_sku": "1HU-004H-000T0",
-    "walmart_sku": 5050122769,
     "manufacturer_url": "https://www.bequiet.com/en/powersupply/4653"
   }
 }

--- a/open-db/RAM/de9f2218-f94c-4f80-a43b-bd7170ac9615.json
+++ b/open-db/RAM/de9f2218-f94c-4f80-a43b-bd7170ac9615.json
@@ -7,7 +7,7 @@
   "metadata": {
     "name": "TeamGroup T-Force DELTA RGB 64GB (2x32GB) DDR4 3000 CL16 Black",
     "manufacturer": "TEAMGROUP",
-    "part_numbers": ["TF3D464G3000HC16CDC01", "TF3D416G3200HC16FDC01"],
+    "part_numbers": ["TF3D464G3000HC16CDC01"],
     "series": "T-Force",
     "variant": "3000 CL16",
     "manufacturer_color": "Black",
@@ -30,6 +30,6 @@
   "rgb": true,
   "lighting": [],
   "general_product_information": {
-    "manufacturer_url": "https://www.teamgroupinc.com/en/product/compare-result/"
+    "manufacturer_url": "https://www.teamgroupinc.com/en/product-detail/memory/T-FORCE/delta-rgb-ddr4-black/delta-rgb-ddr4-black-TF3D464G3000HC16CDC01/"
   }
 }


### PR DESCRIPTION
Fixes #195.\nFixes #223.\n\nRemoves the Walmart SKU from the be quiet! Straight Power 12 750W record because Walmart item 5050122769 resolves to a Corsair PC DIY Precision Toolkit, not the PSU. The existing manufacturer URL remains the be quiet! Straight Power 12 750W page.\n\nValidation:\n- jq empty open-db/PSU/10ae69ee-583a-49ba-ac4a-e6972a7bd8f4.json\n- npx ajv-cli validate --strict=false -s schemas/PSU.schema.json -d open-db/PSU/10ae69ee-583a-49ba-ac4a-e6972a7bd8f4.json\n- git diff --check