### PR TITLE
Fix Crucial MX500 M.2 part number

### DIFF
--- a/open-db/Storage/2c77130b-cfbf-47ae-b868-e6eb205d774f.json
+++ b/open-db/Storage/2c77130b-cfbf-47ae-b868-e6eb205d774f.json
@@ -3,7 +3,7 @@
   "metadata": {
     "name": "Crucial MX500 1TB SSD M.2 SATA",
     "manufacturer": "Crucial",
-    "part_numbers": ["CT1000MX500SSD4", "EC-M2SA"],
+    "part_numbers": ["CT1000MX500SSD4"],
     "series": "MX500",
     "variant": "1000GB",
     "releaseYear": 2018
@@ -14,5 +14,7 @@
   "nvme": false,
   "storage_type": "SSD",
   "lighting": [],
-  "general_product_information": {}
+  "general_product_information": {
+    "manufacturer_url": "https://www.crucial.com/ssd/mx500"
+  }
 }


### PR DESCRIPTION
## Summary
- remove the Sabrent EC-M2SA enclosure SKU from the Crucial MX500 SSD record
- add the Crucial MX500 manufacturer page for the real SSD family

Addresses #170

## Validation
- `PATH="$tmp/node_modules/.bin:$PATH" ./scripts/validate.sh open-db/Storage/2c77130b-cfbf-47ae-b868-e6eb205d774f.json`