### PR TITLE
Fix MSI MAG 274QP QD-OLED X24 record

### DIFF
--- a/open-db/Monitor/27f40dcb-6285-48b4-8a33-e8ffa242dee9.json
+++ b/open-db/Monitor/27f40dcb-6285-48b4-8a33-e8ffa242dee9.json
@@ -7,7 +7,7 @@
   "metadata": {
     "name": "MSI MAG 274QP QD-OLED X24",
     "manufacturer": "MSI",
-    "part_numbers": ["MAG 274QP QD-OLED X24", "MAG 274CF X24"],
+    "part_numbers": ["MAG 274QP QD-OLED X24"],
     "series": "MAG",
     "variant": "274QP QD-OLED X24",
     "last_manually_spec_verified_at": "2026-02-21T11:03:25.282Z"
@@ -15,7 +15,7 @@
   "screen_size": 26.5,
   "refresh_rate": 240,
   "panel_type": "QD-OLED",
-  "response_time": 240,
+  "response_time": 0.03,
   "color": ["BLACK"],
   "viewing_angle": "178° H x 178° V",
   "aspect_ratio": "16:9",
@@ -26,7 +26,6 @@
   "lighting": [],
   "general_product_information": {
     "newegg_sku": "N82E16824475541",
-    "bestbuy_sku": 12008069,
     "walmart_sku": 19020672159,
     "manufacturer_url": "https://www.msi.com/Monitor/MAG-274QP-QD-OLED-X24"
   }


### PR DESCRIPTION
Fixes #224.

Changes:
- remove stray MAG 274CF X24 part number from the QD-OLED record
- correct response_time from 240 to 0.03 ms
- remove the Best Buy SKU that belongs to the separate 1080p MAG 274CF X24 record

Validation: jq empty; npx ajv against Monitor schema.