### PR TITLE
Add SilentiumPC Elementum E2 SI 350W PSU

### DIFF
--- a/open-db/PSU/b5d9eb83-4957-4201-adee-0ba8d943f148.json
+++ b/open-db/PSU/b5d9eb83-4957-4201-adee-0ba8d943f148.json
@@ -1,0 +1,28 @@
+{
+  "opendb_id": "b5d9eb83-4957-4201-adee-0ba8d943f148",
+  "connectors": {
+    "atx_24_pin": 1,
+    "eps_8_pin": 1,
+    "pcie_12vhpwr": 0,
+    "pcie_6_plus_2_pin": 1,
+    "sata": 4,
+    "molex_4_pin": 2,
+    "floppy_4_pin": 0
+  },
+  "metadata": {
+    "name": "SilentiumPC Elementum E2 230V Black 350W Non-Modular 80+ Certified",
+    "manufacturer": "SilentiumPC",
+    "part_numbers": ["SPC196"],
+    "series": "Elementum",
+    "variant": "350W 80+"
+  },
+  "wattage": 350,
+  "form_factor": "ATX",
+  "efficiency_rating": "80+",
+  "modular": "Non-Modular",
+  "color": ["BLACK"],
+  "length": 140,
+  "fanless": false,
+  "lighting": [],
+  "general_product_information": {}
+}

--- a/open-db/PSU/b5d9eb83-4957-4201-adee-0ba8d943f148.json
+++ b/open-db/PSU/b5d9eb83-4957-4201-adee-0ba8d943f148.json
@@ -10,11 +10,11 @@
     "floppy_4_pin": 0
   },
   "metadata": {
-    "name": "SilentiumPC Elementum E2 230V Black 350W Non-Modular 80+ Certified",
+    "name": "SilentiumPC Elementum E2 SI 230V Black 350W Non-Modular 80+ Certified",
     "manufacturer": "SilentiumPC",
     "part_numbers": ["SPC196"],
     "series": "Elementum",
-    "variant": "350W 80+"
+    "variant": "SI 350W 80+"
   },
   "wattage": 350,
   "form_factor": "ATX",


### PR DESCRIPTION
Adds the SilentiumPC Elementum E2 SI 350W (SPC196), which was missing from the DB — only the 550W (SPC252) was present. Specs (connectors, form factor, 80 PLUS efficiency) are from the manufacturer datasheet and 80 PLUS certification, with `manufacturer`/`series` matched to the existing 550W entry.