### PR TITLE
Add AMD Ryzen 7 7700X3D

### DIFF
--- a/open-db/CPU/24b3997b-1de2-42f5-a680-07818370a0da.json
+++ b/open-db/CPU/24b3997b-1de2-42f5-a680-07818370a0da.json
@@ -1,0 +1,58 @@
+{
+  "opendb_id": "24b3997b-1de2-42f5-a680-07818370a0da",
+  "cores": {
+    "total": 8,
+    "performance": 0,
+    "threads": 16,
+    "efficiency": 0
+  },
+  "clocks": {
+    "performance": {
+      "base": 4,
+      "boost": 4.5
+    },
+    "efficiency": {
+      "base": 0,
+      "boost": 0
+    }
+  },
+  "cache": {
+    "l2": 8,
+    "l3": 96,
+    "l1": "8 × 64 KB (32 KB L1I + 32 KB L1D)"
+  },
+  "specifications": {
+    "integratedGraphics": {
+      "model": "AMD Radeon Graphics",
+      "boostClock": 2200,
+      "shaderCount": 128
+    },
+    "memory": {
+      "maxSupport": 128,
+      "types": ["DDR5"],
+      "channels": 2
+    },
+    "tdp": 120,
+    "eccSupport": true,
+    "includesCooler": false,
+    "packaging": "Boxed",
+    "lithography": "TSMC 5nm FinFET, TSMC 6nm FinFET",
+    "simultaneousMultithreading": true
+  },
+  "metadata": {
+    "name": "AMD Ryzen 7 7700X3D",
+    "manufacturer": "AMD",
+    "part_numbers": ["100-100002235WOF", "AMD Ryzen 7 7700X3D", "100100002235WOF"],
+    "series": "Ryzen 7 7000",
+    "variant": "7700X3D",
+    "releaseYear": 2026
+  },
+  "series": "Ryzen 7 7000",
+  "microarchitecture": "Zen 4",
+  "coreFamily": "Raphael",
+  "socket": "AM5",
+  "general_product_information": {
+    "newegg_sku": "N82E16819113941",
+    "manufacturer_url": "https://www.amd.com/en/products/processors/desktops/ryzen/7000-series/amd-ryzen-7-7700x3d.html"
+  }
+}


### PR DESCRIPTION
## Summary

- add the boxed AMD Ryzen 7 7700X3D to the CPU catalog
- include its Zen 4 / AM5 core, clock, cache, memory, graphics, and thermal specifications
- include the boxed manufacturer part number and verified Newegg SKU

## Sources

- [AMD Ryzen 7 7700X3D product page](https://www.amd.com/en/products/processors/desktops/ryzen/7000-series/amd-ryzen-7-7700x3d.html)
- [Newegg Ryzen 7 7700X3D listing](https://www.newegg.com/ryzen-7-7700x3d-ryzen-7000-series-raphael-zen-4-socket-am5-amd-cpu/p/N82E16819113941)

## Validation

- `./scripts/validate.sh open-db/CPU/24b3997b-1de2-42f5-a680-07818370a0da.json`
- `git diff --cached --check`
