### PR TITLE
79c9c7a1-931d-4268-8e7c-e1bbda7d5d4d.json

### DIFF
--- a/open-db/CPUCooler/79c9c7a1-931d-4268-8e7c-e1bbda7d5d4d.json
+++ b/open-db/CPUCooler/79c9c7a1-931d-4268-8e7c-e1bbda7d5d4d.json
@@ -2,9 +2,9 @@
   "opendb_id": "79c9c7a1-931d-4268-8e7c-e1bbda7d5d4d",
   "metadata": {
     "name": "DeepCool LE360 WH V2 360mm White",
-    "manufacturer": "DeepCool",
+    "manufacturer": "Deepcool",
     "part_numbers": ["R-LE360-WHAMMN-G-2"],
-    "series": "LE V2",
+    "series": "LE360",
     "variant": "",
     "releaseYear": 2025,
     "manufacturer_color": "White"

--- a/open-db/CPUCooler/79c9c7a1-931d-4268-8e7c-e1bbda7d5d4d.json
+++ b/open-db/CPUCooler/79c9c7a1-931d-4268-8e7c-e1bbda7d5d4d.json
@@ -1,17 +1,18 @@
 {
   "opendb_id": "79c9c7a1-931d-4268-8e7c-e1bbda7d5d4d",
   "metadata": {
-    "name": "Deepcool LE360 V2 Water 360mm White",
-    "manufacturer": "Deepcool",
+    "name": "DeepCool LE360 WH V2 360mm White",
+    "manufacturer": "DeepCool",
     "part_numbers": ["R-LE360-WHAMMN-G-2"],
-    "series": "LE360",
-    "variant": "White",
-    "releaseYear": null
+    "series": "LE V2",
+    "variant": "",
+    "releaseYear": 2025,
+    "manufacturer_color": "White"
   },
   "min_fan_rpm": 500,
   "max_fan_rpm": 2100,
-  "min_noise_level": 31.6,
-  "max_noise_level": null,
+  "min_noise_level": null,
+  "max_noise_level": 31.6,
   "color": ["WHITE"],
   "height": 65,
   "cpu_sockets": [
@@ -20,7 +21,6 @@
     "LGA 1150",
     "LGA 1151",
     "LGA 1155",
-    "LGA 1156",
     "LGA 1200",
     "LGA 1700",
     "LGA 1851"
@@ -28,8 +28,10 @@
   "water_cooled": true,
   "radiator_size": 360,
   "fanless": false,
-  "fan_size": null,
-  "fan_quantity": null,
-  "lighting": [],
-  "general_product_information": {}
+  "fan_size": 120,
+  "fan_quantity": 3,
+  "lighting": ["ARGB"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.deepcool.com/products/Cooling/cpuliquidcoolers/LE360-WH-V2-Liquid-CPU-Cooler-1851-1700-AM5/2025/20139.shtml"
+  }
 }


### PR DESCRIPTION
This pull request completes and corrects the specifications for the DeepCool LE360 WH V2 White.

Changes:
- Added the three included 120 mm fans
- Added ARGB lighting
- Corrected the maximum noise level
- Updated the supported CPU sockets
- Added the manufacturer color
- Added the release year
- Added the official manufacturer product page

Source:
https://www.deepcool.com/products/Cooling/cpuliquidcoolers/LE360-WH-V2-Liquid-CPU-Cooler-1851-1700-AM5/2025/20139.shtml