### PR TITLE
Normalize NetworkCard manufacturer names

### DIFF
--- a/open-db/NetworkCard/1550b7bc-43b6-4038-8ca9-9793b748f06d.json
+++ b/open-db/NetworkCard/1550b7bc-43b6-4038-8ca9-9793b748f06d.json
@@ -2,7 +2,7 @@
   "opendb_id": "1550b7bc-43b6-4038-8ca9-9793b748f06d",
   "metadata": {
     "name": "Syba SD-PEX24055 10 Gb/s Ethernet PCIe x4",
-    "manufacturer": "IO CREST",
+    "manufacturer": "IO Crest",
     "part_numbers": ["SD-PEX24055"]
   },
   "general_product_information": {

--- a/open-db/NetworkCard/221151ea-7ba6-45e2-9c88-48cbd6df36d6.json
+++ b/open-db/NetworkCard/221151ea-7ba6-45e2-9c88-48cbd6df36d6.json
@@ -2,7 +2,7 @@
   "opendb_id": "221151ea-7ba6-45e2-9c88-48cbd6df36d6",
   "metadata": {
     "name": "Syba SY-ADA24029 Gigabit Ethernet USB Type-A",
-    "manufacturer": "SYBA",
+    "manufacturer": "Syba",
     "part_numbers": ["SY-ADA24029"]
   },
   "general_product_information": {

--- a/open-db/NetworkCard/66ecd97b-b02e-422a-941b-a6d67e7e5733.json
+++ b/open-db/NetworkCard/66ecd97b-b02e-422a-941b-a6d67e7e5733.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["SD-PEX24009"],
     "name": "Syba SD-PEX24009 Gigabit Ethernet PCIe x1 Network Adapter",
-    "manufacturer": "SYBA"
+    "manufacturer": "Syba"
   },
   "general_product_information": {
     "amazon_sku": "B004M18EEC",

--- a/open-db/NetworkCard/b1b7289a-da42-4a2e-bf1b-80f3b38767ff.json
+++ b/open-db/NetworkCard/b1b7289a-da42-4a2e-bf1b-80f3b38767ff.json
@@ -2,7 +2,7 @@
   "opendb_id": "b1b7289a-da42-4a2e-bf1b-80f3b38767ff",
   "metadata": {
     "name": "Edimax EN-9130TXL 100 Mb/s Ethernet PCI",
-    "manufacturer": "Edimax",
+    "manufacturer": "EDiMAX",
     "part_numbers": ["EN-9130TXL"]
   },
   "general_product_information": {

--- a/open-db/NetworkCard/c6a83c7a-3658-449c-b55f-933192d15e50.json
+++ b/open-db/NetworkCard/c6a83c7a-3658-449c-b55f-933192d15e50.json
@@ -2,7 +2,7 @@
   "opendb_id": "c6a83c7a-3658-449c-b55f-933192d15e50",
   "metadata": {
     "name": "Syba SI-PEX24042 4 x Gigabit Ethernet PCIe x1",
-    "manufacturer": "SYBA",
+    "manufacturer": "Syba",
     "part_numbers": ["SI-PEX24042"]
   },
   "general_product_information": {

--- a/open-db/NetworkCard/f38ad8fa-d873-4928-b74b-bafdb9ae6266.json
+++ b/open-db/NetworkCard/f38ad8fa-d873-4928-b74b-bafdb9ae6266.json
@@ -2,7 +2,7 @@
   "opendb_id": "f38ad8fa-d873-4928-b74b-bafdb9ae6266",
   "metadata": {
     "name": "Syba SD-PEX24066 2 x 2.5 Gb/s Ethernet PCIe x1",
-    "manufacturer": "IO CREST",
+    "manufacturer": "IO Crest",
     "part_numbers": ["SD-PEX24066"]
   },
   "general_product_information": {


### PR DESCRIPTION
Normalizes clear case/whitespace-equivalent manufacturer variants in the NetworkCard category.

Only a unique existing spelling with at least a 2:1 count advantage was selected; no canonical names were invented. Tied, close, or semantically distinct manufacturer names were intentionally left unchanged for human review.

Validation: changed files were checked against the category schema and diff whitespace.