### PR TITLE
Normalize Webcam manufacturer names

### DIFF
--- a/open-db/Webcam/773b40f9-b4a7-4aa8-be04-3c9143fe4c95.json
+++ b/open-db/Webcam/773b40f9-b4a7-4aa8-be04-3c9143fe4c95.json
@@ -2,7 +2,7 @@
   "opendb_id": "773b40f9-b4a7-4aa8-be04-3c9143fe4c95",
   "metadata": {
     "name": "Adesso Cybertrack H4P 1080p Webcam",
-    "manufacturer": "Adesso",
+    "manufacturer": "ADESSO",
     "part_numbers": ["Cybertrack H4P"]
   },
   "connectivity_type": [],

--- a/open-db/Webcam/8e23250c-785b-46aa-ae31-6c87db9bd436.json
+++ b/open-db/Webcam/8e23250c-785b-46aa-ae31-6c87db9bd436.json
@@ -2,7 +2,7 @@
   "opendb_id": "8e23250c-785b-46aa-ae31-6c87db9bd436",
   "metadata": {
     "name": "Avermedia 510 4K UHD Webcam",
-    "manufacturer": "Avermedia",
+    "manufacturer": "AVerMedia",
     "part_numbers": ["PW510"]
   },
   "connectivity_type": [],

--- a/open-db/Webcam/d1d77f44-fcd9-436a-b75c-73348215cca2.json
+++ b/open-db/Webcam/d1d77f44-fcd9-436a-b75c-73348215cca2.json
@@ -2,7 +2,7 @@
   "opendb_id": "d1d77f44-fcd9-436a-b75c-73348215cca2",
   "metadata": {
     "name": "Avermedia HD 310 1080p Webcam",
-    "manufacturer": "Avermedia",
+    "manufacturer": "AVerMedia",
     "part_numbers": ["PW310O"]
   },
   "connectivity_type": [],


### PR DESCRIPTION
Normalizes clear case/whitespace-equivalent manufacturer variants in the Webcam category.

Only a unique existing spelling with at least a 2:1 count advantage was selected; no canonical names were invented. Tied, close, or semantically distinct manufacturer names were intentionally left unchanged for human review.

Validation: changed files were checked against the category schema and diff whitespace.