### PR TITLE
Normalize CaseFan manufacturer names

### DIFF
--- a/open-db/CaseFan/59ba65fc-4d33-4899-b98d-17226f436135.json
+++ b/open-db/CaseFan/59ba65fc-4d33-4899-b98d-17226f436135.json
@@ -2,7 +2,7 @@
   "opendb_id": "59ba65fc-4d33-4899-b98d-17226f436135",
   "metadata": {
     "name": "Montech RX120 Pro Black",
-    "manufacturer": "MONTECH",
+    "manufacturer": "Montech",
     "variant": "120 PRO",
     "part_numbers": ["RX120PB"],
     "series": "RX",

--- a/open-db/CaseFan/5ea18583-4c0b-408d-aad5-ebd7e5a2a126.json
+++ b/open-db/CaseFan/5ea18583-4c0b-408d-aad5-ebd7e5a2a126.json
@@ -2,7 +2,7 @@
   "opendb_id": "5ea18583-4c0b-408d-aad5-ebd7e5a2a126",
   "metadata": {
     "name": "Montech AX120 Pro White",
-    "manufacturer": "MONTECH",
+    "manufacturer": "Montech",
     "series": "AX",
     "variant": "120 Pro",
     "part_numbers": ["AX120PW"],

--- a/open-db/CaseFan/81e8438b-17cb-424c-bb07-3f4c4cb51773.json
+++ b/open-db/CaseFan/81e8438b-17cb-424c-bb07-3f4c4cb51773.json
@@ -2,7 +2,7 @@
   "opendb_id": "81e8438b-17cb-424c-bb07-3f4c4cb51773",
   "metadata": {
     "name": "Lian Li UNI Fan TL White Wireless 140mm PWM ARGB",
-    "manufacturer": "Lian Li ",
+    "manufacturer": "Lian Li",
     "variant": "140mm White",
     "part_numbers": ["14TL1W1W"],
     "series": "UNI TL Wireless",

--- a/open-db/CaseFan/b2f5a3d9-b55e-4a89-a53a-d5b0cb111e1c.json
+++ b/open-db/CaseFan/b2f5a3d9-b55e-4a89-a53a-d5b0cb111e1c.json
@@ -2,7 +2,7 @@
   "opendb_id": "b2f5a3d9-b55e-4a89-a53a-d5b0cb111e1c",
   "metadata": {
     "name": "ASUS PRIME OEM 120mm Fan White",
-    "manufacturer": "Asus",
+    "manufacturer": "ASUS",
     "part_numbers": []
   },
   "size": 120,

--- a/open-db/CaseFan/e78cec7c-f594-42f7-b784-e8cbeb57daf7.json
+++ b/open-db/CaseFan/e78cec7c-f594-42f7-b784-e8cbeb57daf7.json
@@ -2,7 +2,7 @@
   "opendb_id": "e78cec7c-f594-42f7-b784-e8cbeb57daf7",
   "metadata": {
     "name": "Montech AX120 Pro Black",
-    "manufacturer": "MONTECH",
+    "manufacturer": "Montech",
     "series": "AX",
     "variant": "120 Pro",
     "part_numbers": ["AX120PB"],


### PR DESCRIPTION
Normalizes clear case/whitespace-equivalent manufacturer variants in the CaseFan category.

Only a unique existing spelling with at least a 2:1 count advantage was selected; no canonical names were invented. Tied, close, or semantically distinct manufacturer names were intentionally left unchanged for human review.

Validation: changed files were checked against the category schema and diff whitespace.