### PR TITLE
Normalize Speaker manufacturer names

### DIFF
--- a/open-db/Speaker/072154cc-ff78-4a1d-ae2d-7012b5f4e551.json
+++ b/open-db/Speaker/072154cc-ff78-4a1d-ae2d-7012b5f4e551.json
@@ -2,7 +2,7 @@
   "opendb_id": "072154cc-ff78-4a1d-ae2d-7012b5f4e551",
   "metadata": {
     "name": "Mackie CR3-X 2.0 Channel 50 W White Speaker System",
-    "manufacturer": "Mackie",
+    "manufacturer": "MACKIE",
     "part_numbers": ["2053023-00", "CR3-X+RVSM1+RRS190S"]
   },
   "lighting": [],

--- a/open-db/Speaker/085e29a1-53d6-4ba2-b8ef-20717f5debf8.json
+++ b/open-db/Speaker/085e29a1-53d6-4ba2-b8ef-20717f5debf8.json
@@ -2,7 +2,7 @@
   "opendb_id": "085e29a1-53d6-4ba2-b8ef-20717f5debf8",
   "metadata": {
     "name": "M-Audio Studiophile AV20 2.0 Channel 10 W Speaker System",
-    "manufacturer": "M-Audio",
+    "manufacturer": "M-AUDIO",
     "part_numbers": ["AV20", "Studiophile AV20"]
   },
   "lighting": [],

--- a/open-db/Speaker/14fd0e45-1619-48c7-8a35-68fb07806a1d.json
+++ b/open-db/Speaker/14fd0e45-1619-48c7-8a35-68fb07806a1d.json
@@ -2,7 +2,7 @@
   "opendb_id": "14fd0e45-1619-48c7-8a35-68fb07806a1d",
   "metadata": {
     "name": "Creative Pebble Pro Minimalist 2.0 USB-C Computer Speakers",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF1710AA003"],
     "series": "Creative Pebble Pro Minimalist 2.0 USB-C Computer Speakers"
   },

--- a/open-db/Speaker/3905878b-0f00-4bb4-8bc3-8bf043612c83.json
+++ b/open-db/Speaker/3905878b-0f00-4bb4-8bc3-8bf043612c83.json
@@ -2,7 +2,7 @@
   "opendb_id": "3905878b-0f00-4bb4-8bc3-8bf043612c83",
   "metadata": {
     "name": "M-Audio BX5 D3 Crimson 1.0 Channel 100 W Speaker System",
-    "manufacturer": "M-Audio",
+    "manufacturer": "M-AUDIO",
     "part_numbers": ["BX5 D3 Crimson"]
   },
   "lighting": [],

--- a/open-db/Speaker/6653f4e2-3841-497a-ae03-363129069324.json
+++ b/open-db/Speaker/6653f4e2-3841-497a-ae03-363129069324.json
@@ -2,7 +2,7 @@
   "opendb_id": "6653f4e2-3841-497a-ae03-363129069324",
   "metadata": {
     "name": "Creative Pebble V3 Minimalistic 2.0 USB-C Desktop Speakers",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF1700AA000"],
     "series": "Creative Pebble V3 Minimalistic 2.0 USB-C Desktop Speakers"
   },

--- a/open-db/Speaker/6ef50b5a-101b-4e50-9451-5b5d77c28755.json
+++ b/open-db/Speaker/6ef50b5a-101b-4e50-9451-5b5d77c28755.json
@@ -2,7 +2,7 @@
   "opendb_id": "6ef50b5a-101b-4e50-9451-5b5d77c28755",
   "metadata": {
     "name": "Mackie MR8mk3 2.0 Channel 170 W Speaker System",
-    "manufacturer": "Mackie",
+    "manufacturer": "MACKIE",
     "part_numbers": ["MR8mk3"]
   },
   "lighting": [],

--- a/open-db/Speaker/7d0f7de7-9def-467f-8482-5b39e84905e5.json
+++ b/open-db/Speaker/7d0f7de7-9def-467f-8482-5b39e84905e5.json
@@ -2,7 +2,7 @@
   "opendb_id": "7d0f7de7-9def-467f-8482-5b39e84905e5",
   "metadata": {
     "name": "Creative Labs T50 2.0 40 W Speaker System",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF1665AA001"]
   },
   "lighting": [],

--- a/open-db/Speaker/83c4d1fb-ba2d-4a77-b6cc-7edd7ae1d73f.json
+++ b/open-db/Speaker/83c4d1fb-ba2d-4a77-b6cc-7edd7ae1d73f.json
@@ -2,7 +2,7 @@
   "opendb_id": "83c4d1fb-ba2d-4a77-b6cc-7edd7ae1d73f",
   "metadata": {
     "name": "M-Audio BX6 Carbon 1.0 Channel 100W Speaker System",
-    "manufacturer": "M-Audio",
+    "manufacturer": "M-AUDIO",
     "part_numbers": ["BX6 CARBON"]
   },
   "lighting": [],

--- a/open-db/Speaker/93736a58-2591-4eb9-8713-6287654c1bcb.json
+++ b/open-db/Speaker/93736a58-2591-4eb9-8713-6287654c1bcb.json
@@ -2,7 +2,7 @@
   "opendb_id": "93736a58-2591-4eb9-8713-6287654c1bcb",
   "metadata": {
     "name": "M-Audio BX8 D2 2.0 Channel 260 W Speaker System",
-    "manufacturer": "M-Audio",
+    "manufacturer": "M-AUDIO",
     "part_numbers": ["BX8 D2", "9900-65175-00"]
   },
   "lighting": [],

--- a/open-db/Speaker/c6fba417-5049-4dc0-9d4d-b12f70fc452a.json
+++ b/open-db/Speaker/c6fba417-5049-4dc0-9d4d-b12f70fc452a.json
@@ -2,7 +2,7 @@
   "opendb_id": "c6fba417-5049-4dc0-9d4d-b12f70fc452a",
   "metadata": {
     "name": "Creative Pebble Pro (Black) Minimalist 2.0 USB-C Computer Speakers",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF1710AA000"],
     "series": "Creative Pebble Pro (Black) Minimalist 2.0 USB-C Computer"
   },

--- a/open-db/Speaker/c92c5780-6de2-4de2-96c1-ce904f0803d9.json
+++ b/open-db/Speaker/c92c5780-6de2-4de2-96c1-ce904f0803d9.json
@@ -2,7 +2,7 @@
   "opendb_id": "c92c5780-6de2-4de2-96c1-ce904f0803d9",
   "metadata": {
     "name": "Creative Pebble SE Minimalist 2.0 USB-C Powered PC Speakers",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF1725AA001"],
     "series": "Creative Pebble SE Minimalist 2.0 USB-C Powered PC Speakers"
   },

--- a/open-db/Speaker/d0bbb38a-ae41-4aba-a38c-965d246c1a82.json
+++ b/open-db/Speaker/d0bbb38a-ae41-4aba-a38c-965d246c1a82.json
@@ -2,7 +2,7 @@
   "opendb_id": "d0bbb38a-ae41-4aba-a38c-965d246c1a82",
   "metadata": {
     "name": "Creative Pebble SE Minimalist 2.0 USB-C Powered PC Speakers",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF1725AA000"],
     "series": "Creative Pebble SE Minimalist 2.0 USB-C Powered PC Speakers"
   },

--- a/open-db/Speaker/e0b2103f-5b09-4c01-8c64-d32dae275ab2.json
+++ b/open-db/Speaker/e0b2103f-5b09-4c01-8c64-d32dae275ab2.json
@@ -2,7 +2,7 @@
   "opendb_id": "e0b2103f-5b09-4c01-8c64-d32dae275ab2",
   "metadata": {
     "name": "Creative Pebble X Plus 2.1 USB-C Computer Speakers",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF0495AA000"],
     "series": "Creative Pebble X Plus 2.1 USB-C Computer Speakers"
   },

--- a/open-db/Speaker/e66f4956-dd0d-4f78-9fe6-4d4ac1505083.json
+++ b/open-db/Speaker/e66f4956-dd0d-4f78-9fe6-4d4ac1505083.json
@@ -2,7 +2,7 @@
   "opendb_id": "e66f4956-dd0d-4f78-9fe6-4d4ac1505083",
   "metadata": {
     "name": "Creative Labs Sound BlasterX Kratos S5 2.1 Channel Speaker System",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF0470AA001"]
   },
   "lighting": [],

--- a/open-db/Speaker/e71c91ea-8bc8-431e-95eb-9cc8b7192076.json
+++ b/open-db/Speaker/e71c91ea-8bc8-431e-95eb-9cc8b7192076.json
@@ -2,7 +2,7 @@
   "opendb_id": "e71c91ea-8bc8-431e-95eb-9cc8b7192076",
   "metadata": {
     "name": "Creative Stage SE 2.0 Bluetooth Sound Bar Speaker - Black",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF8410AA000"],
     "series": "Creative Stage SE"
   },

--- a/open-db/Speaker/ea0fe1eb-2429-4726-a661-3a60bdcd70c8.json
+++ b/open-db/Speaker/ea0fe1eb-2429-4726-a661-3a60bdcd70c8.json
@@ -2,7 +2,7 @@
   "opendb_id": "ea0fe1eb-2429-4726-a661-3a60bdcd70c8",
   "metadata": {
     "name": "Mackie MR5mk3 2.0 Channel 100W Speaker System",
-    "manufacturer": "Mackie",
+    "manufacturer": "MACKIE",
     "part_numbers": ["MR5mk3", "2041890-00"]
   },
   "lighting": [],

--- a/open-db/Speaker/ee901053-ea5b-4af1-8236-78195a13b39c.json
+++ b/open-db/Speaker/ee901053-ea5b-4af1-8236-78195a13b39c.json
@@ -2,7 +2,7 @@
   "opendb_id": "ee901053-ea5b-4af1-8236-78195a13b39c",
   "metadata": {
     "name": "Creative Labs Stage 360 2.1 Channel 180 W Speaker System",
-    "manufacturer": "Creative",
+    "manufacturer": "CREATIVE",
     "part_numbers": ["51MF8385AA001", "MF8385"]
   },
   "lighting": [],

--- a/open-db/Speaker/f6d843fe-1c7d-4938-9aaa-e9baf98b2bb7.json
+++ b/open-db/Speaker/f6d843fe-1c7d-4938-9aaa-e9baf98b2bb7.json
@@ -2,7 +2,7 @@
   "opendb_id": "f6d843fe-1c7d-4938-9aaa-e9baf98b2bb7",
   "metadata": {
     "name": "Mackie MR6mk3 2.0 130 W Speaker System",
-    "manufacturer": "Mackie",
+    "manufacturer": "MACKIE",
     "part_numbers": ["MR6mk3"]
   },
   "lighting": [],


### PR DESCRIPTION
Normalizes clear case/whitespace-equivalent manufacturer variants in the Speaker category.

Only a unique existing spelling with at least a 2:1 count advantage was selected; no canonical names were invented. Tied, close, or semantically distinct manufacturer names were intentionally left unchanged for human review.

Validation: changed files were checked against the category schema and diff whitespace.