### PR TITLE
Normalize PCCase manufacturer names

### DIFF
--- a/open-db/PCCase/86816bd7-32e5-4493-a219-c70e72d4dec6.json
+++ b/open-db/PCCase/86816bd7-32e5-4493-a219-c70e72d4dec6.json
@@ -2,7 +2,7 @@
   "opendb_id": "86816bd7-32e5-4493-a219-c70e72d4dec6",
   "metadata": {
     "name": "Montech TG3 ATX Mid Tower Black",
-    "manufacturer": "Montech",
+    "manufacturer": "MONTECH",
     "part_numbers": []
   },
   "form_factor": "ATX Mid Tower",

--- a/open-db/PCCase/a665c556-dbb3-47bf-afa6-a561d66c6f0f.json
+++ b/open-db/PCCase/a665c556-dbb3-47bf-afa6-a561d66c6f0f.json
@@ -2,7 +2,7 @@
   "opendb_id": "a665c556-dbb3-47bf-afa6-a561d66c6f0f",
   "metadata": {
     "name": "Montech TG3 ATX Mid Tower White",
-    "manufacturer": "Montech",
+    "manufacturer": "MONTECH",
     "part_numbers": []
   },
   "form_factor": "ATX Mid Tower",

--- a/open-db/PCCase/d86b31ae-7f2e-4900-a972-cdcd9f1ade8e.json
+++ b/open-db/PCCase/d86b31ae-7f2e-4900-a972-cdcd9f1ade8e.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "part_numbers": ["MG120", "CGR-5TMZB-G", "385TMZ0.0002"],
-    "manufacturer": "COUGAR",
+    "manufacturer": "Cougar",
     "name": "COUGAR MG120 Black Micro ATX Mini Tower Case",
     "releaseYear": 2019,
     "series": "MG",


### PR DESCRIPTION
Normalizes clear case/whitespace-equivalent manufacturer variants in the PCCase category.

Only a unique existing spelling with at least a 2:1 count advantage was selected; no canonical names were invented. Tied, close, or semantically distinct manufacturer names were intentionally left unchanged for human review.

Validation: changed files were checked against the category schema and diff whitespace.