### PR TITLE
Normalize RAM manufacturer names

### DIFF
--- a/open-db/RAM/6b996b31-dd08-4aca-968b-f68ff1b3e1fc.json
+++ b/open-db/RAM/6b996b31-dd08-4aca-968b-f68ff1b3e1fc.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "name": "RAM Mushkin D4 3600 16GB C14 RedlineST K2",
-    "manufacturer": "MUSHKIN",
+    "manufacturer": "Mushkin",
     "series": "RedlineST K2",
     "variant": null,
     "releaseYear": 0,


### PR DESCRIPTION
Normalizes clear case/whitespace-equivalent manufacturer variants in the RAM category.

Only a unique existing spelling with at least a 2:1 count advantage was selected; no canonical names were invented. Tied, close, or semantically distinct manufacturer names were intentionally left unchanged for human review.

Validation: changed files were checked against the category schema and diff whitespace.