### PR TITLE
Normalize PSU manufacturer names

### DIFF
--- a/open-db/PSU/004c110f-4e42-4037-b095-de793ee31610.json
+++ b/open-db/PSU/004c110f-4e42-4037-b095-de793ee31610.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF650 Black 230V ATX 650W Non-Modular 80+ Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF650D-HA0B-US",
       "R-PF650D-HA0B-CN",

--- a/open-db/PSU/0a455c64-4d39-4b46-af14-324c6a847948.json
+++ b/open-db/PSU/0a455c64-4d39-4b46-af14-324c6a847948.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "SeaSonic FOCUS Plus Platinum 750 W 80+ Platinum Certified Fully Modular ATX Power Supply",
-    "manufacturer": "Seasonic",
+    "manufacturer": "SeaSonic",
     "series": "FOCUS Plus Platinum",
     "variant": null,
     "releaseYear": 2017,

--- a/open-db/PSU/11bfbb55-831b-4245-889e-7ccdc085b78c.json
+++ b/open-db/PSU/11bfbb55-831b-4245-889e-7ccdc085b78c.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DA700N Black ATX 700W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-BZ-DA700N"],
     "series": "DA700N",
     "variant": "700W Bronze"

--- a/open-db/PSU/15c2a1e1-00f6-4bbf-8d36-48f95c1e50cc.json
+++ b/open-db/PSU/15c2a1e1-00f6-4bbf-8d36-48f95c1e50cc.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PX850G Black ATX 850W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PX850G-FC0B-USR-PX850G-FC0B-WOR-PX850G-FC0B-BPR-PX850G-FC0B-UKR-PX850G-FC0B-CNR-PX850G-FC0B-JPR-PX850G-FC0B-EUR-PX850G-FC0B-AU"
     ],

--- a/open-db/PSU/1e52af03-aeaf-4fc0-b44f-70a119923a86.json
+++ b/open-db/PSU/1e52af03-aeaf-4fc0-b44f-70a119923a86.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PL650D Black 650W Non-Modular 80+ Bronze Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PL650D-FC0B-US",
       "R-PL650D-FC0B-JP",

--- a/open-db/PSU/21b5ab4c-6a03-4fd6-b425-00446688c0e7.json
+++ b/open-db/PSU/21b5ab4c-6a03-4fd6-b425-00446688c0e7.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "FOCUS GM-850",
-    "manufacturer": "Seasonic",
+    "manufacturer": "SeaSonic",
     "series": "FOCUS",
     "variant": "GM",
     "releaseYear": 0,

--- a/open-db/PSU/2243c3fb-65f6-4769-b6a6-734cb9455eca.json
+++ b/open-db/PSU/2243c3fb-65f6-4769-b6a6-734cb9455eca.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ750-M-V2L Black / Green 750W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-GD-DQ750-M-V2L", "DP-DQ750-M-V2L"],
     "series": "DQ750-M-V2L",
     "variant": "750W Gold"

--- a/open-db/PSU/2fa3007a-446b-4cf7-a0e0-fbe3f1f34678.json
+++ b/open-db/PSU/2fa3007a-446b-4cf7-a0e0-fbe3f1f34678.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF500 230V Black ATX 500W Non-Modular 80+ Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF500D-HA0B-US",
       "R-PF500D-HA0B-AR",

--- a/open-db/PSU/33070eff-4729-4a12-936c-9a23064b6f37.json
+++ b/open-db/PSU/33070eff-4729-4a12-936c-9a23064b6f37.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PQ650M ATX 650W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["R-PQ650M-FA0B-US"],
     "series": "PQ650M",
     "variant": "650W Gold"

--- a/open-db/PSU/34b25afd-f69b-460a-8542-a1aedb6d7b71.json
+++ b/open-db/PSU/34b25afd-f69b-460a-8542-a1aedb6d7b71.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN750D White 750W Non-Modular 80+ Gold Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN750D-FC0W-US",
       "R-PN750D-FC0W-EU",

--- a/open-db/PSU/3547a19b-c8bc-471e-bc41-78a855421a03.json
+++ b/open-db/PSU/3547a19b-c8bc-471e-bc41-78a855421a03.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PM750D Black ATX 750W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PM750D-FA0B-US",
       "R-PM750D-FA0B-JP",

--- a/open-db/PSU/39a8ddb4-a31e-45a4-8a08-016d36f8301b.json
+++ b/open-db/PSU/39a8ddb4-a31e-45a4-8a08-016d36f8301b.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool GamerStorm DQ-M Black / Silver 750W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DQ750-M"],
     "series": "GamerStorm",
     "variant": "750W Gold"

--- a/open-db/PSU/39b057a4-103f-4482-9817-dbb5a1d8912f.json
+++ b/open-db/PSU/39b057a4-103f-4482-9817-dbb5a1d8912f.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK550D Black Certified ATX 550W Non-Modular 80+ Bronze",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK550D-FA0B-US",
       "R-PK550D-FA0B-BP",

--- a/open-db/PSU/3b044bcb-f656-4ea6-af99-72f6808c9bdb.json
+++ b/open-db/PSU/3b044bcb-f656-4ea6-af99-72f6808c9bdb.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ750-M-V2L White / Black 750W 80+ Gold Certified Fully Modular ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-DQ750-M-V2L WH"],
     "series": "DQ750-M-V2L",
     "variant": "750W Gold"

--- a/open-db/PSU/3fb93df7-75e2-48dc-aaed-8e0259e60269.json
+++ b/open-db/PSU/3fb93df7-75e2-48dc-aaed-8e0259e60269.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PX1000G Black 1000W Fully Modular 80+ Gold Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PXA00G-FC0B-US",
       "R-PXA00G-FC0B-CN",

--- a/open-db/PSU/4589c35a-82c2-4b84-933a-bda8bb84417c.json
+++ b/open-db/PSU/4589c35a-82c2-4b84-933a-bda8bb84417c.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PM600D Black ATX 600W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PM600D-FA0B-US",
       "R-PM600D-FA0B-BR",

--- a/open-db/PSU/4fbc8462-0268-44a7-aad2-ec611868087f.json
+++ b/open-db/PSU/4fbc8462-0268-44a7-aad2-ec611868087f.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PQ1000M Black 1000W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["R-PQA00M-FA0B-US"],
     "series": "PQ1000M",
     "variant": "1000W Gold"

--- a/open-db/PSU/4fc09dac-7be9-438c-af25-13a41d6a364e.json
+++ b/open-db/PSU/4fc09dac-7be9-438c-af25-13a41d6a364e.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN850D Black 850W Non-Modular 80+ Gold Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN850D-FC0B-US",
       "R-PN850D-FC0B-UK",

--- a/open-db/PSU/53e369bb-8892-4945-b88b-e55e62729464.json
+++ b/open-db/PSU/53e369bb-8892-4945-b88b-e55e62729464.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ650-M-V2L ATX 650W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-DQ650-M-V2L", "DP-GD-DQ650-M-V2L"],
     "series": "DQ650-M-V2L",
     "variant": "650W Gold"

--- a/open-db/PSU/54aad5ef-0398-495c-b28e-68d48a6f0a7d.json
+++ b/open-db/PSU/54aad5ef-0398-495c-b28e-68d48a6f0a7d.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK450D Black 450W 80+ Bronze Certified ATX Non-Modular",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK450D-FA0B-US",
       "R-PK450D-FA0B-WO",

--- a/open-db/PSU/597f41a1-3f42-425d-90b2-084afb837273.json
+++ b/open-db/PSU/597f41a1-3f42-425d-90b2-084afb837273.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN750M ATX 750W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN750M-FC0B-US",
       "PN750M",

--- a/open-db/PSU/5bc6ae31-26a7-4719-9d58-b18eeaf9dddd.json
+++ b/open-db/PSU/5bc6ae31-26a7-4719-9d58-b18eeaf9dddd.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN750M White 750W 80+ Gold Fully Modular",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN750M-FC0W-US",
       "PN750M WH",

--- a/open-db/PSU/62d615ea-75ca-4232-8dee-279ea88abc60.json
+++ b/open-db/PSU/62d615ea-75ca-4232-8dee-279ea88abc60.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN650M ATX 650W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN650M-FC0B-US",
       "R-PN650M-FC0B-EU",

--- a/open-db/PSU/6459b1b5-d5db-4c4d-9fb0-454eb208a6fe.json
+++ b/open-db/PSU/6459b1b5-d5db-4c4d-9fb0-454eb208a6fe.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PM700D Black ATX 700W Non-Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PM700D-FA0B-US",
       "R-PM700D-FA0B-AR",

--- a/open-db/PSU/64b9c413-19b9-487f-ab50-7f633eb142f1.json
+++ b/open-db/PSU/64b9c413-19b9-487f-ab50-7f633eb142f1.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN850M 850W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN850M-FC0B-US",
       "R-PN850M-FC0B-WO",

--- a/open-db/PSU/66cc8ce1-73c4-4455-9867-d9e8d2197eb5.json
+++ b/open-db/PSU/66cc8ce1-73c4-4455-9867-d9e8d2197eb5.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ850M-V3L Black 850W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-DQ850M-FB0B-US",
       "R-DQ850M-FB0B-UK",

--- a/open-db/PSU/66d1eae4-4b5d-45c8-bf4e-89f7cf104095.json
+++ b/open-db/PSU/66d1eae4-4b5d-45c8-bf4e-89f7cf104095.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ750M-V3L Black ATX 750W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-DQ750M-FB0B-US",
       "R-DQ750M-FB0B-WO",

--- a/open-db/PSU/67f774d1-25f6-44f8-bb69-728790798647.json
+++ b/open-db/PSU/67f774d1-25f6-44f8-bb69-728790798647.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK750D Black ATX 750W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK750D-FA0B-US",
       "R-PK750D-FA0B-JP",

--- a/open-db/PSU/695d6787-eca0-4ac3-8164-b2974a4f7ef0.json
+++ b/open-db/PSU/695d6787-eca0-4ac3-8164-b2974a4f7ef0.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK700D Black 700W Non-Modular 80+ Bronze Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK700D-FA0B-USR-PK700D-FA0B-BPR-PK700D-FA0B-JPR-PK700D-FA0B-EUR-PK700D-FA0B-BRR-PK700D-FA0B-CNR-PK700D-FA0B-AUR-PK700D-FA0B-UKR-PK700D-FA0B-ARR-PK700D-FA0B-WO"
     ],

--- a/open-db/PSU/6bc8d284-be4a-4041-9322-5fa1c7e380ce.json
+++ b/open-db/PSU/6bc8d284-be4a-4041-9322-5fa1c7e380ce.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK600D Black ATX 600W Non-Modular 80+ Bronze",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK600D-FA0B-USR-PK600D-FA0B-CNR-PK600D-FA0B-BPR-PK600D-FA0B-BRR-PK600D-FA0B-EUR-PK600D-FA0B-UKR-PK600D-FA0B-JPR-PK600D-FA0B-WOR-PK600D-FA0B-AUR-PK600D-FA0B-AR"
     ],

--- a/open-db/PSU/6c469373-f2d2-4694-8f53-bbf5def925d0.json
+++ b/open-db/PSU/6c469373-f2d2-4694-8f53-bbf5def925d0.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN650D Black ATX 650W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN650D-FC0B-US",
       "PN650D",

--- a/open-db/PSU/6e6769f6-ff8d-4669-89a8-9308441799bd.json
+++ b/open-db/PSU/6e6769f6-ff8d-4669-89a8-9308441799bd.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PM500D Black ATX 500W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PM500D-FA0B-US",
       "R-PM500D-FA0B-BU",

--- a/open-db/PSU/7018e03f-dcc1-4a1b-8a06-cc91b8aaa78b.json
+++ b/open-db/PSU/7018e03f-dcc1-4a1b-8a06-cc91b8aaa78b.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PQ750M Black 750W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["R-PQ750M-FA0B-US"],
     "series": "PQ750M",
     "variant": "750W Gold"

--- a/open-db/PSU/71a4d390-f819-4935-ae5e-7ee26a90b27d.json
+++ b/open-db/PSU/71a4d390-f819-4935-ae5e-7ee26a90b27d.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "750W DeepCool PL750D 80 Plus Bronze PSU",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "series": "PL",
     "variant": "PL750D",
     "releaseYear": 0,

--- a/open-db/PSU/71a4d390-f819-4935-ae5e-7ee26a90b27d.json
+++ b/open-db/PSU/71a4d390-f819-4935-ae5e-7ee26a90b27d.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "750W DeepCool PL750D 80 Plus Bronze PSU",
-    "manufacturer": "DeepCool",
+    "manufacturer": "Deepcool",
     "series": "PL",
     "variant": "PL750D",
     "releaseYear": 0,

--- a/open-db/PSU/768bee4c-cc08-4068-ab0d-dfb9fbbce17c.json
+++ b/open-db/PSU/768bee4c-cc08-4068-ab0d-dfb9fbbce17c.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN750D Black ATX 750W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN750D-FC0B-US",
       "R-PN750D-FC0B-UK",

--- a/open-db/PSU/7c414d5d-7a7c-4b7e-9c9b-44bd1e7a12e8.json
+++ b/open-db/PSU/7c414d5d-7a7c-4b7e-9c9b-44bd1e7a12e8.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN550D Black 550W Non-Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN550D-FC0B-US",
       "PN550D",

--- a/open-db/PSU/8082c5e1-babb-4d8f-9388-c2c7fc0f2102.json
+++ b/open-db/PSU/8082c5e1-babb-4d8f-9388-c2c7fc0f2102.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF550 Black 230V 550W Non-Modular 80+ Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF550D-HA0B-US",
       "R-PF550D-HA0B-EU",

--- a/open-db/PSU/83c3e6e2-7862-4626-a795-618b9d3bbad6.json
+++ b/open-db/PSU/83c3e6e2-7862-4626-a795-618b9d3bbad6.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PX1300P Black / Silver ATX 1300W Fully Modular 80+ Platinum Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PXD00P-FC0B-US",
       "R-PXD00P-FC0B-AU",

--- a/open-db/PSU/84921cc6-42eb-48ee-8623-227d3e5b436b.json
+++ b/open-db/PSU/84921cc6-42eb-48ee-8623-227d3e5b436b.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DA600-M 600W Fully Modular 80+ Bronze Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-BZ-DA600-MFM"],
     "series": "DA600-M",
     "variant": "600W Bronze"

--- a/open-db/PSU/894f9bb1-d9c0-4ff6-982d-984599f4d123.json
+++ b/open-db/PSU/894f9bb1-d9c0-4ff6-982d-984599f4d123.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PL750D Black 750W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PL750D-FC0B-US",
       "R-PL750D-FC0B-UK",

--- a/open-db/PSU/89c8c3b2-5009-4d88-8b4c-d0459ce5c30d.json
+++ b/open-db/PSU/89c8c3b2-5009-4d88-8b4c-d0459ce5c30d.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ650ST ATX 650W Non-Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DQ650ST"],
     "series": "DQ650ST",
     "variant": "650W Gold"

--- a/open-db/PSU/89d8fea9-6aaf-4f87-9281-bd8b80ead5ad.json
+++ b/open-db/PSU/89d8fea9-6aaf-4f87-9281-bd8b80ead5ad.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "SeaSonic Electronics Prime Snow Silent 750 Titanium SSR-750TR 750W 80+ Titanium ATX12V & EPS12V Full Modular 135mm FDB Fan Power On Self Tester 12 Year Warranty Power Supply Color White",
-    "manufacturer": "Seasonic",
+    "manufacturer": "SeaSonic",
     "series": "PRIME SNOW SILENT",
     "variant": "750 Titanium",
     "releaseYear": 2022,

--- a/open-db/PSU/8a610fb0-f4ba-419e-a2c9-573ae196d48d.json
+++ b/open-db/PSU/8a610fb0-f4ba-419e-a2c9-573ae196d48d.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN650M White 650W Fully Modular 80+ Gold Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN650M-FC0W-US",
       "R-PN650M-FC0W-UK",

--- a/open-db/PSU/96b1762f-216d-428b-bc44-4fa8eff6ba68.json
+++ b/open-db/PSU/96b1762f-216d-428b-bc44-4fa8eff6ba68.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PQ850M 850W 80+ Gold Certified Fully Modular",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["R-PQ850M-FA0B-US"],
     "series": "PQ850M",
     "variant": "850W Gold"

--- a/open-db/PSU/97530ee8-4a96-4c36-ab39-322aa6787b8d.json
+++ b/open-db/PSU/97530ee8-4a96-4c36-ab39-322aa6787b8d.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DA500 Black / Gold 500W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-BZ-DA500N", "DA500"],
     "series": "DA500",
     "variant": "500W Bronze"

--- a/open-db/PSU/991d00c2-04ac-449f-a8a2-72a9ee8c66a6.json
+++ b/open-db/PSU/991d00c2-04ac-449f-a8a2-72a9ee8c66a6.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Seasonic Focus V4 GX-1000 Fully Modular ATX Power Supply - 1000 Watts ATX 3.1 - White",
-    "manufacturer": "Seasonic",
+    "manufacturer": "SeaSonic",
     "part_numbers": [
       "FOCUS-GX-1000W-V4",
       "SRP-FGX102-A5A32SF WHITE",

--- a/open-db/PSU/9c4d5aac-2206-41c3-be6c-a1b8dd54b524.json
+++ b/open-db/PSU/9c4d5aac-2206-41c3-be6c-a1b8dd54b524.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK650D Black ATX 650W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK650D-FA0B-US",
       "R-PK650D-FA0B-JP",

--- a/open-db/PSU/9efd8ceb-ceda-4100-bd22-649de40451be.json
+++ b/open-db/PSU/9efd8ceb-ceda-4100-bd22-649de40451be.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ1000M-V3L Black 1000W Fully Modular 80+ Gold Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-DQA00M-FB0B-US",
       "R-DQA00M-FB0B-UK",

--- a/open-db/PSU/a2a36e2f-100e-4997-a906-9455cbe87821.json
+++ b/open-db/PSU/a2a36e2f-100e-4997-a906-9455cbe87821.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PL800D Black 800W Non-Modular 80+ Bronze",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PL800D-FC0B-US",
       "R-PL800D-FC0B-AU",

--- a/open-db/PSU/a4930301-0e34-4a59-9dc4-d9b74764a399.json
+++ b/open-db/PSU/a4930301-0e34-4a59-9dc4-d9b74764a399.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF600 Black 230V ATX 600W Non-Modular 80+ Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF600D-HA0B-US",
       "R-PF600D-HA0B-AU",

--- a/open-db/PSU/a6ce6ae0-1d5c-4a79-a010-f6e95d21f345.json
+++ b/open-db/PSU/a6ce6ae0-1d5c-4a79-a010-f6e95d21f345.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN850M White 850W Fully Modular 80+ Gold Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN850M-FC0W-US",
       "R-PN850M-FC0W-UK",

--- a/open-db/PSU/a87520b4-35b4-43fc-9a67-c5a1661be856.json
+++ b/open-db/PSU/a87520b4-35b4-43fc-9a67-c5a1661be856.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "SilverStone PS-ST1500-TI 1500 W Power Supply",
-    "manufacturer": "SilverStone",
+    "manufacturer": "Silverstone",
     "series": "Strider Titanium",
     "variant": null,
     "releaseYear": 2017,

--- a/open-db/PSU/a94cf164-a9a4-4bed-b9cb-9a9416bb21ce.json
+++ b/open-db/PSU/a94cf164-a9a4-4bed-b9cb-9a9416bb21ce.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN550D White 550W Non-Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN550D-FC0W-US",
       "R-PN550D-FC0W-WO",

--- a/open-db/PSU/aeed0332-5571-4807-acda-db5126803097.json
+++ b/open-db/PSU/aeed0332-5571-4807-acda-db5126803097.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PX1200G ATX 1200W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PXC00G-FC0B-US",
       "R-PXC00G-FC0B-AU",

--- a/open-db/PSU/af6e092f-5872-4ec8-8126-947d3cc22d21.json
+++ b/open-db/PSU/af6e092f-5872-4ec8-8126-947d3cc22d21.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ750ST ATX 750W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DQ750ST"],
     "series": "DQ750ST",
     "variant": "750W Gold"

--- a/open-db/PSU/b0942691-31c6-4585-befc-80c408a63ce4.json
+++ b/open-db/PSU/b0942691-31c6-4585-befc-80c408a63ce4.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK800D Black 800W Non-Modular 80+ Bronze Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK800D-FA0B-US",
       "R-PK800D-FA0B-JP",

--- a/open-db/PSU/b1cc596d-5cf5-45a1-9d85-fc46e22f6e6e.json
+++ b/open-db/PSU/b1cc596d-5cf5-45a1-9d85-fc46e22f6e6e.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF450 Black 230V ATX 450W Non-Modular 80+",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF450D-HA0B-US",
       "R-PF450D-HA0B-UK",

--- a/open-db/PSU/b2ba420f-75f1-4e35-92e1-8362ae8753e9.json
+++ b/open-db/PSU/b2ba420f-75f1-4e35-92e1-8362ae8753e9.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PK500D Black ATX 500W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PK500D-FA0B-US",
       "R-PK500D-FA0B-AU",

--- a/open-db/PSU/b4a599ac-a4a3-4d20-ab27-5de60ad12f47.json
+++ b/open-db/PSU/b4a599ac-a4a3-4d20-ab27-5de60ad12f47.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PX850G White 850W 80+ Gold Fully Modular",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PX850G-FC0W-USR-PX850G-FC0W-BPR-PX850G-FC0W-EUPX850G WHR-PX850G-FC0W-WOR-PX850G-FC0W-UKR-PX850G-FC0W-AU"
     ],

--- a/open-db/PSU/b51de56a-7c74-4fb9-9a6d-2ee4e9953f11.json
+++ b/open-db/PSU/b51de56a-7c74-4fb9-9a6d-2ee4e9953f11.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PM650D Black ATX 650W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PM650D-FA0B-US",
       "R-PM650D-FA0B-JP",

--- a/open-db/PSU/b5b53080-b4f0-4e7d-be1a-3684ccb91559.json
+++ b/open-db/PSU/b5b53080-b4f0-4e7d-be1a-3684ccb91559.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool GamerStorm DQ-M Black / Silver 650W Fully Modular 80+ Gold Certified ATX",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DQ650-M"],
     "series": "GamerStorm",
     "variant": "650W Gold"

--- a/open-db/PSU/b783a981-b747-4f40-80a4-2d8a59951492.json
+++ b/open-db/PSU/b783a981-b747-4f40-80a4-2d8a59951492.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ-M-V2L Black / Green 850W Fully Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-GD-DQ850-M-V2L", "DP-DQ850-M-V2L", "DQ850-M-V2L"],
     "series": "DQ-M-V2L",
     "variant": "850W Gold"

--- a/open-db/PSU/ba0e4047-b88a-42a6-8cbd-e6a50cb9cc2c.json
+++ b/open-db/PSU/ba0e4047-b88a-42a6-8cbd-e6a50cb9cc2c.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF750 Black 230V ATX 750W Non-Modular 80+",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF750D-HA0B-US",
       "R-PF750D-HA0B-WO",

--- a/open-db/PSU/bad41e49-0a8d-4994-9653-efd04b809912.json
+++ b/open-db/PSU/bad41e49-0a8d-4994-9653-efd04b809912.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "MSI A850GLS MLG EDITION PSU",
-    "manufacturer": "MSI ",
+    "manufacturer": "MSI",
     "part_numbers": ["A850GLS MLG EDITION", "MAG A850GLS MLG EDITION"],
     "series": "A850GLS",
     "variant": "MLG Edition",

--- a/open-db/PSU/bbe1504f-b17f-4e4f-aa66-fea86c97e8b4.json
+++ b/open-db/PSU/bbe1504f-b17f-4e4f-aa66-fea86c97e8b4.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN850D White ATX 850W Non-Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN850D-FC0W-US",
       "R-PN850D-FC0W-UK",

--- a/open-db/PSU/bd9fd5a5-0c0b-4129-b90c-61222af880b9.json
+++ b/open-db/PSU/bd9fd5a5-0c0b-4129-b90c-61222af880b9.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PL550D Black ATX 550W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PL550D-FC0B-US",
       "R-PL550D-FC0B-UK",

--- a/open-db/PSU/cc638bbc-373c-46f9-bc87-b1d3009da709.json
+++ b/open-db/PSU/cc638bbc-373c-46f9-bc87-b1d3009da709.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Silverstone Strider 650 W 80+ Gold Certified Fully Modular ATX Power Supply",
-    "manufacturer": "SilverStone",
+    "manufacturer": "Silverstone",
     "part_numbers": ["RNAB07K64NGSN", "SST-ST65F-GS"],
     "series": "Strider Gold S",
     "variant": "ST65F-G",

--- a/open-db/PSU/cd89fd83-3211-4c64-9d87-b5c4d673462a.json
+++ b/open-db/PSU/cd89fd83-3211-4c64-9d87-b5c4d673462a.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Seasonic G12 GM-650 (2024)",
-    "manufacturer": "Seasonic",
+    "manufacturer": "SeaSonic",
     "series": "G12 GM",
     "variant": null,
     "releaseYear": 2024,

--- a/open-db/PSU/cf8b1c07-c48e-4bcf-96f3-5786bb329af0.json
+++ b/open-db/PSU/cf8b1c07-c48e-4bcf-96f3-5786bb329af0.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PX1000P Black / Silver ATX 1000W Fully Modular 80+ Platinum Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PXA00P-FC0B-US",
       "R-PXA00P-FC0B-WO",

--- a/open-db/PSU/d250bb64-fcaf-4c08-8a28-903402631cc8.json
+++ b/open-db/PSU/d250bb64-fcaf-4c08-8a28-903402631cc8.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PX1000G White 1000W Fully Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["PX1000G WH"],
     "series": "PX1000G",
     "variant": "1000W Gold"

--- a/open-db/PSU/d3ade2c0-6436-45a2-819a-890461737326.json
+++ b/open-db/PSU/d3ade2c0-6436-45a2-819a-890461737326.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF350 Black 230V ATX 350W Non-Modular 80+ Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF350D-HA0B-US",
       "R-PF350D-HA0B-AR",

--- a/open-db/PSU/db8c0bd8-f5c7-455a-b17d-0b9053211ce4.json
+++ b/open-db/PSU/db8c0bd8-f5c7-455a-b17d-0b9053211ce4.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DN400 ATX 400W Non-Modular",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DN400"],
     "series": "DN400",
     "variant": "400W "

--- a/open-db/PSU/dccfd7f5-bf9f-4a7a-8a03-0f60374195f5.json
+++ b/open-db/PSU/dccfd7f5-bf9f-4a7a-8a03-0f60374195f5.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DA600N Black ATX 600W Non-Modular 80+ Bronze Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DP-BZ-DA600N"],
     "series": "DA600N",
     "variant": "600W Bronze"

--- a/open-db/PSU/e3d7d286-efd5-4aa1-b7c2-78177d46c5d3.json
+++ b/open-db/PSU/e3d7d286-efd5-4aa1-b7c2-78177d46c5d3.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PN650D White 650W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PN650D-FC0W-US",
       "R-PN650D-FC0W-UK",

--- a/open-db/PSU/e6bab828-9c9f-44d9-b4a3-c6a825048c5f.json
+++ b/open-db/PSU/e6bab828-9c9f-44d9-b4a3-c6a825048c5f.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool GamerStorm DQ-M Black / Silver 850W Fully Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DQ850-M"],
     "series": "GamerStorm",
     "variant": "850W Gold"

--- a/open-db/PSU/ef385e94-2e44-4f55-b38c-5df017d08ad3.json
+++ b/open-db/PSU/ef385e94-2e44-4f55-b38c-5df017d08ad3.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool DQ550ST ATX 550W Non-Modular 80+ Gold",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": ["DQ550ST"],
     "series": "DQ550ST",
     "variant": "550W Gold"

--- a/open-db/PSU/f0e5c813-acc3-425a-839d-7aa350343850.json
+++ b/open-db/PSU/f0e5c813-acc3-425a-839d-7aa350343850.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF700 Black 230V ATX 700W Non-Modular 80+ Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF700D-HA0B-USR-PF700D-HA0B-AUR-PF700D-HA0B-CNR-PF700D-HA0B-UKR-PF700D-HA0B-WOR-PF700D-HA0B-BPR-PF700D-HA0B-EUR-PF700D-HA0B-AR"
     ],

--- a/open-db/PSU/f42bad5f-51a4-4718-9d09-e455288cf23d.json
+++ b/open-db/PSU/f42bad5f-51a4-4718-9d09-e455288cf23d.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PM850D ATX 850W Non-Modular 80+ Gold Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PM850D-FA0B-US",
       "R-PM850D-FA0B-BR",

--- a/open-db/PSU/f8fb357c-184a-42b1-9fdf-519bb050756b.json
+++ b/open-db/PSU/f8fb357c-184a-42b1-9fdf-519bb050756b.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Seasonic PRIME Ultra 650 Platinum SSR-650PD2",
-    "manufacturer": "Seasonic",
+    "manufacturer": "SeaSonic",
     "series": "PRIME Ultra Platinum",
     "variant": "650W",
     "releaseYear": 2019,

--- a/open-db/PSU/fc3c427f-7349-4743-aa39-3e4771dc5bb7.json
+++ b/open-db/PSU/fc3c427f-7349-4743-aa39-3e4771dc5bb7.json
@@ -11,7 +11,7 @@
   },
   "metadata": {
     "name": "Deepcool PF400 Black 230V ATX 400W Non-Modular 80+ Certified",
-    "manufacturer": "Deepcool",
+    "manufacturer": "DeepCool",
     "part_numbers": [
       "R-PF400D-HA0B-USR-PF400D-HA0B-EUR-PF400D-HA0B-BPR-PF400D-HA0B-CNR-PF400D-HA0B-AUR-PF400D-HA0B-UKR-PF400D-HA0B-ARR-PF400D-HA0B-WO"
     ],


### PR DESCRIPTION
Normalizes PSU manufacturer spellings, including the requested canonical form `DeepCool`.

This follow-up changes `metadata.manufacturer` from `Deepcool` to `DeepCool` for all affected PSUs. Product identity, variants, and all other metadata remain unchanged.

Validation: all 71 newly changed JSON files parsed successfully and the diff is whitespace-clean.