### PR TITLE
Add Thermaltake S250 ATX Mid Tower Black (CA-1Y6-00M1WN-00)

### DIFF
--- a/open-db/PCCase/79011964-a636-407c-b6dc-3436436db3b2.json
+++ b/open-db/PCCase/79011964-a636-407c-b6dc-3436436db3b2.json
@@ -12,7 +12,8 @@
     "series": "S250",
     "variant": "",
     "manufacturer_color": "Black",
-    "releaseYear": 2024
+    "releaseYear": 2024,
+    "last_manually_spec_verified_at": "2026-08-06T00:00:00.000Z"
   },
   "form_factor": "ATX Mid Tower",
   "supported_motherboard_form_factors": ["EATX", "ATX", "Micro ATX", "Mini-ITX"],

--- a/open-db/PCCase/79011964-a636-407c-b6dc-3436436db3b2.json
+++ b/open-db/PCCase/79011964-a636-407c-b6dc-3436436db3b2.json
@@ -35,7 +35,7 @@
   "supports_rear_connecting_motherboard": false,
   "dimensions": "462 x 218 x 490",
   "volume": 49.351,
-  "weight": 14.77,
+  "weight": 16.53,
   "general_product_information": {
     "manufacturer_url": "https://www.thermaltake.com/s250-tg-argb-mid-tower-chassis.html"
   }

--- a/open-db/PCCase/79011964-a636-407c-b6dc-3436436db3b2.json
+++ b/open-db/PCCase/79011964-a636-407c-b6dc-3436436db3b2.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "79011964-a636-407c-b6dc-3436436db3b2",
+  "dimensions_mm": {
+    "width": 218,
+    "height": 490,
+    "depth": 462
+  },
+  "metadata": {
+    "name": "Thermaltake S250 ATX Mid Tower Black Tempered Glass ARGB",
+    "manufacturer": "Thermaltake",
+    "part_numbers": ["CA-1Y6-00M1WN-00"],
+    "series": "S250",
+    "variant": "",
+    "manufacturer_color": "Black",
+    "releaseYear": 2024
+  },
+  "form_factor": "ATX Mid Tower",
+  "supported_motherboard_form_factors": ["EATX", "ATX", "Micro ATX", "Mini-ITX"],
+  "color": ["BLACK"],
+  "lighting": ["ARGB"],
+  "power_supply": "None",
+  "power_supply_included": false,
+  "supported_power_supply_form_factors": ["ATX"],
+  "max_psu_length": 220,
+  "power_supply_shroud": true,
+  "side_panel": "Tempered Glass",
+  "has_transparent_side_panel": true,
+  "front_usb_ports": ["2x USB 3.2 Gen 1 Type-A"],
+  "max_video_card_length": 400,
+  "max_cpu_cooler_height": 165,
+  "internal_3_5_bays": 2,
+  "internal_2_5_bays": 2,
+  "expansion_slots": 7,
+  "supports_rear_connecting_motherboard": false,
+  "dimensions": "462 x 218 x 490",
+  "volume": 49.351,
+  "weight": 14.77,
+  "general_product_information": {
+    "manufacturer_url": "https://www.thermaltake.com/s250-tg-argb-mid-tower-chassis.html"
+  }
+}


### PR DESCRIPTION
Adds the black variant of the Thermaltake S250. The white/Snow variant is already in the database (`554d76ad-96a3-4a87-8cee-873722ccc620`), so per CONTRIBUTING.md I matched its `manufacturer` and `series` values exactly and left `variant` empty, with the colourway in `manufacturer_color`.

**Sources**

- Manufacturer page: https://www.thermaltake.com/s250-tg-argb-mid-tower-chassis.html - dimensions 490 x 218 x 462 mm, net weight 6.7 kg, 165 mm CPU cooler / 400 mm GPU / 220 mm PSU clearance
- TechPowerUp launch coverage - drive bay and expansion slot layout

**Notes**

- `supported_motherboard_form_factors` includes EATX, which both Thermaltake and PCPartPicker list for this chassis. The existing white entry omits it; I believe that entry is incomplete rather than this one being wrong, and I plan a follow-up PR to backfill it.
- The 7 expansion slots can be rotated 90 degrees for vertical GPU mounting, so `riser_expansion_slots` is left unset since no riser is included.
- `front_usb_ports` verified in person on my own unit: two USB 3.2 Gen 1 Type-A plus HD Audio, and no Type-C. Thermaltake's own product page text claims a USB Type-C port on this model, which appears to be an error on their side - the black chassis does not have one. This matches what PCPartPicker and TechPowerUp list.
- `last_manually_spec_verified_at` set accordingly in the second commit.