### PR TITLE
Backfill specs for Thermaltake S250 White (554d76ad)

### DIFF
--- a/open-db/PCCase/554d76ad-96a3-4a87-8cee-873722ccc620.json
+++ b/open-db/PCCase/554d76ad-96a3-4a87-8cee-873722ccc620.json
@@ -1,29 +1,42 @@
 {
   "opendb_id": "554d76ad-96a3-4a87-8cee-873722ccc620",
+  "dimensions_mm": {
+    "width": 218,
+    "height": 490,
+    "depth": 462
+  },
   "metadata": {
     "name": "Thermaltake S250 ATX Mid Tower White Tempered Glass ARGB",
     "manufacturer": "Thermaltake",
     "part_numbers": ["CA-1Y6-00M6WN-00"],
     "series": "S250",
-    "variant": ""
+    "variant": "",
+    "manufacturer_color": "Snow",
+    "releaseYear": 2024
   },
-  "supported_motherboard_form_factors": ["ATX", "Micro ATX", "Mini-ITX"],
+  "supported_motherboard_form_factors": ["EATX", "ATX", "Micro ATX", "Mini-ITX"],
   "form_factor": "ATX Mid Tower",
   "color": ["WHITE"],
   "power_supply": "None",
+  "power_supply_included": false,
   "side_panel": "Tempered Glass",
   "has_transparent_side_panel": true,
   "front_panel_usb": "USB 3.2 Gen 1 Type-A",
   "max_video_card_length": 400,
-  "max_cpu_cooler_height": null,
+  "max_cpu_cooler_height": 165,
+  "max_psu_length": 220,
+  "power_supply_shroud": true,
   "internal_3_5_bays": 2,
   "internal_2_5_bays": 2,
   "expansion_slots": 7,
+  "supports_rear_connecting_motherboard": false,
   "dimensions": "462 x 218 x 490",
   "volume": 49.351,
-  "weight": null,
-  "supported_power_supply_form_factors": [],
-  "front_usb_ports": [],
-  "lighting": [],
-  "general_product_information": {}
+  "weight": 14.77,
+  "supported_power_supply_form_factors": ["ATX"],
+  "front_usb_ports": ["2x USB 3.2 Gen 1 Type-A"],
+  "lighting": ["ARGB"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.thermaltake.com/s250-tg-argb-mid-tower-chassis.html"
+  }
 }


### PR DESCRIPTION
The S250 white entry is missing several fields that are documented on Thermaltake's product page. Same chassis as the black variant added in #314.

**Filled in**

- `max_cpu_cooler_height` (was null) and `weight` (was null)
- `dimensions_mm`, `max_psu_length`, `power_supply_shroud`, `power_supply_included`, `supports_rear_connecting_motherboard`
- `supported_power_supply_form_factors`, `front_usb_ports`, `lighting` (were all empty arrays)
- `general_product_information.manufacturer_url` (was an empty object)
- `metadata.manufacturer_color` (Snow, Thermaltake's own name for this colourway) and `metadata.releaseYear`

**Also changed**

- Added EATX to `supported_motherboard_form_factors`. Thermaltake and PCPartPicker both list EATX support for this chassis, and the entry previously omitted it.

**Notes**

- `opendb_id` is unchanged, and the deprecated `front_panel_usb` string was left as it was rather than removed.
- I own the black variant, not this one, so `last_manually_spec_verified_at` is deliberately not set here. Everything above comes from the manufacturer page, which covers both colourways of the same chassis.

Source: https://www.thermaltake.com/s250-tg-argb-mid-tower-chassis.html