### PR TITLE
Normalize Logitech manufacturers across setup categories

### DIFF
--- a/open-db/Accessory/474f240d-5cb2-4cab-806c-395c371cf489.json
+++ b/open-db/Accessory/474f240d-5cb2-4cab-806c-395c371cf489.json
@@ -2,7 +2,7 @@
   "opendb_id": "474f240d-5cb2-4cab-806c-395c371cf489",
   "metadata": {
     "name": "Logitech G X56 H.O.T.A.S. Space/Flight Controller",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["6b71ccc1454dbd9d", "X56 VR", "945-000058"]
   },
   "general_product_information": {

--- a/open-db/Headphones/0245e3dc-7ab2-4f6e-9e8f-80031becd29c.json
+++ b/open-db/Headphones/0245e3dc-7ab2-4f6e-9e8f-80031becd29c.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["981-001061"],
     "name": "Logitech G435 Headset",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/035dd4eb-033f-464f-9a07-de2c4a62769a.json
+++ b/open-db/Headphones/035dd4eb-033f-464f-9a07-de2c4a62769a.json
@@ -2,7 +2,8 @@
   "opendb_id": "035dd4eb-033f-464f-9a07-de2c4a62769a",
   "metadata": {
     "part_numbers": ["981-000742"],
-    "name": "Logitech G935 7.1 Channel Headset"
+    "name": "Logitech G935 7.1 Channel Headset",
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/051a945e-cb59-4f3c-90d2-179a35f72d85.json
+++ b/open-db/Headphones/051a945e-cb59-4f3c-90d2-179a35f72d85.json
@@ -2,7 +2,7 @@
   "opendb_id": "051a945e-cb59-4f3c-90d2-179a35f72d85",
   "metadata": {
     "name": "Logitech G733 Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000882"]
   },
   "connection_types": [],

--- a/open-db/Headphones/0586c7ce-5a70-4909-99c6-e719ce163388.json
+++ b/open-db/Headphones/0586c7ce-5a70-4909-99c6-e719ce163388.json
@@ -2,7 +2,7 @@
   "opendb_id": "0586c7ce-5a70-4909-99c6-e719ce163388",
   "metadata": {
     "name": "Logitech G733 Gaming Headset Closed-Back Purple",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000889"]
   },
   "connection_types": [],

--- a/open-db/Headphones/0b9ef486-4932-493b-bd10-afb0be6963ee.json
+++ b/open-db/Headphones/0b9ef486-4932-493b-bd10-afb0be6963ee.json
@@ -2,7 +2,7 @@
   "opendb_id": "0b9ef486-4932-493b-bd10-afb0be6963ee",
   "metadata": {
     "name": "Logitech Pro X Closed-Back Headphones",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "981-000906                                                    981-000907",
       "981-000906"

--- a/open-db/Headphones/15b69907-081d-4f4e-b1d8-d92b572812db.json
+++ b/open-db/Headphones/15b69907-081d-4f4e-b1d8-d92b572812db.json
@@ -2,7 +2,7 @@
   "opendb_id": "15b69907-081d-4f4e-b1d8-d92b572812db",
   "metadata": {
     "name": "Logitech ASTRO A50 X Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "939-002126                                                    939-002128",
       "939-002126"

--- a/open-db/Headphones/2196a93f-43f5-4654-8b62-08450f6c6588.json
+++ b/open-db/Headphones/2196a93f-43f5-4654-8b62-08450f6c6588.json
@@ -2,7 +2,7 @@
   "opendb_id": "2196a93f-43f5-4654-8b62-08450f6c6588",
   "metadata": {
     "name": "Astro A10 Closed-Back Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["939-001844", "939-001847"]
   },
   "connection_types": [],

--- a/open-db/Headphones/254fe6c8-4ca6-4772-8be0-bf816024bd29.json
+++ b/open-db/Headphones/254fe6c8-4ca6-4772-8be0-bf816024bd29.json
@@ -2,7 +2,7 @@
   "opendb_id": "254fe6c8-4ca6-4772-8be0-bf816024bd29",
   "metadata": {
     "name": "Logitech G733 Closed-Back Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000942", "984-000942"]
   },
   "connection_types": [],

--- a/open-db/Headphones/2835d98e-5172-421f-9810-7d532d1b55a3.json
+++ b/open-db/Headphones/2835d98e-5172-421f-9810-7d532d1b55a3.json
@@ -2,7 +2,7 @@
   "opendb_id": "2835d98e-5172-421f-9810-7d532d1b55a3",
   "metadata": {
     "name": "Logitech G930 Wireless Gaming Headset 7.1 Channel Closed-Back Black / Red",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000257"]
   },
   "connection_types": [],

--- a/open-db/Headphones/31d0f9a8-8bcc-49b4-aff3-47a31ab2dc80.json
+++ b/open-db/Headphones/31d0f9a8-8bcc-49b4-aff3-47a31ab2dc80.json
@@ -2,7 +2,7 @@
   "opendb_id": "31d0f9a8-8bcc-49b4-aff3-47a31ab2dc80",
   "metadata": {
     "name": "Logitech Pro X 7.1 Channel Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000817"]
   },
   "connection_types": [],

--- a/open-db/Headphones/34e18e1d-e38c-469a-ab34-f0a4960811cd.json
+++ b/open-db/Headphones/34e18e1d-e38c-469a-ab34-f0a4960811cd.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["981-000906"],
     "name": "1MORE EHD9001TA In Ear",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/3d0f6df0-61ed-4c87-bc4b-c3b67f9d8a6a.json
+++ b/open-db/Headphones/3d0f6df0-61ed-4c87-bc4b-c3b67f9d8a6a.json
@@ -2,7 +2,7 @@
   "opendb_id": "3d0f6df0-61ed-4c87-bc4b-c3b67f9d8a6a",
   "metadata": {
     "name": "Logitech G335 Closed-Back Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-001017"]
   },
   "connection_types": [],

--- a/open-db/Headphones/4490d688-9942-42c0-8e7a-3ff1d319bc9a.json
+++ b/open-db/Headphones/4490d688-9942-42c0-8e7a-3ff1d319bc9a.json
@@ -2,7 +2,8 @@
   "opendb_id": "4490d688-9942-42c0-8e7a-3ff1d319bc9a",
   "metadata": {
     "part_numbers": ["981-000742"],
-    "name": "Logitech G935 7.1 Channel Headset"
+    "name": "Logitech G935 7.1 Channel Headset",
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/46756b5e-c684-4a7d-a2db-e4db2bd453e6.json
+++ b/open-db/Headphones/46756b5e-c684-4a7d-a2db-e4db2bd453e6.json
@@ -2,7 +2,7 @@
   "opendb_id": "46756b5e-c684-4a7d-a2db-e4db2bd453e6",
   "metadata": {
     "name": "Logitech G335 Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000977"]
   },
   "connection_types": [],

--- a/open-db/Headphones/48004c77-c210-4581-a830-8114e1becec3.json
+++ b/open-db/Headphones/48004c77-c210-4581-a830-8114e1becec3.json
@@ -2,7 +2,7 @@
   "opendb_id": "48004c77-c210-4581-a830-8114e1becec3",
   "metadata": {
     "name": "Logitech G231 PRODIGY Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000625"]
   },
   "connection_types": [],

--- a/open-db/Headphones/4d407c31-f3a9-4b3c-bc4e-098cb9567855.json
+++ b/open-db/Headphones/4d407c31-f3a9-4b3c-bc4e-098cb9567855.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["981-001023"],
     "name": "Logitech G335 Headset",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/563dc4c9-cf0c-499e-8a2d-cf6aaddb5a92.json
+++ b/open-db/Headphones/563dc4c9-cf0c-499e-8a2d-cf6aaddb5a92.json
@@ -2,7 +2,7 @@
   "opendb_id": "563dc4c9-cf0c-499e-8a2d-cf6aaddb5a92",
   "metadata": {
     "name": "Logitech FITS Closed In-Ear Headset with Microphone",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "985-001177                                                    985-001183",
       "985-001177"

--- a/open-db/Headphones/583410fe-2299-4655-b7b5-fac1343c017e.json
+++ b/open-db/Headphones/583410fe-2299-4655-b7b5-fac1343c017e.json
@@ -2,7 +2,7 @@
   "opendb_id": "583410fe-2299-4655-b7b5-fac1343c017e",
   "metadata": {
     "name": "Logitech G733 LIGHTSPEED Wireless RGB Gaming Headset White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000863", "981-000867", "981-000882"],
     "releaseYear": 2020
   },

--- a/open-db/Headphones/646350c4-4e7e-4c53-9881-ed245ee9bc96.json
+++ b/open-db/Headphones/646350c4-4e7e-4c53-9881-ed245ee9bc96.json
@@ -2,7 +2,7 @@
   "opendb_id": "646350c4-4e7e-4c53-9881-ed245ee9bc96",
   "metadata": {
     "name": "Logitech G933 Artemis Spectrum Snow 7.1 Channel Closed-Back Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000620", "981-000585"]
   },
   "connection_types": [],

--- a/open-db/Headphones/68acefc8-8586-4db5-a381-64d571657c78.json
+++ b/open-db/Headphones/68acefc8-8586-4db5-a381-64d571657c78.json
@@ -2,7 +2,7 @@
   "opendb_id": "68acefc8-8586-4db5-a381-64d571657c78",
   "metadata": {
     "name": "Logitech ASTRO A50 (GEN 5) Closed-Back White/Red Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "939-002229                                                    939-002231                                                    939-002230",
       "939-002229"

--- a/open-db/Headphones/6a21a709-3b18-4dad-8623-7cffa7d6ef8d.json
+++ b/open-db/Headphones/6a21a709-3b18-4dad-8623-7cffa7d6ef8d.json
@@ -2,7 +2,7 @@
   "opendb_id": "6a21a709-3b18-4dad-8623-7cffa7d6ef8d",
   "metadata": {
     "name": "Logitech G535 LIGHTSPEED Closed-Back Wireless Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "981-000971                                                    981-000973                                                    981-000972",
       "981-000971"

--- a/open-db/Headphones/7227e426-b6e8-4da5-a99f-961147745cf8.json
+++ b/open-db/Headphones/7227e426-b6e8-4da5-a99f-961147745cf8.json
@@ -2,7 +2,7 @@
   "opendb_id": "7227e426-b6e8-4da5-a99f-961147745cf8",
   "metadata": {
     "name": "Logitech G733 Lightspeed Wireless Gaming Headset - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000867", "981-000863"],
     "series": "Logitech G",
     "variant": "G733 Wirelesss Black",

--- a/open-db/Headphones/79dc725a-0292-4521-86e1-39a24e810cf5.json
+++ b/open-db/Headphones/79dc725a-0292-4521-86e1-39a24e810cf5.json
@@ -2,7 +2,7 @@
   "opendb_id": "79dc725a-0292-4521-86e1-39a24e810cf5",
   "metadata": {
     "name": "Logitech PRO X 2 Wireless Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "981-001262                                                    981-001263                                                    981-001264",
       "981-001262"

--- a/open-db/Headphones/85551eda-f07d-4d9d-8172-eda5978a77c0.json
+++ b/open-db/Headphones/85551eda-f07d-4d9d-8172-eda5978a77c0.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["981-000701"],
     "name": "Logitech G233 PRODIGY Headset",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/99aea780-dd1e-4044-a832-5374a3b55845.json
+++ b/open-db/Headphones/99aea780-dd1e-4044-a832-5374a3b55845.json
@@ -2,7 +2,7 @@
   "opendb_id": "99aea780-dd1e-4044-a832-5374a3b55845",
   "metadata": {
     "name": "Logitech G635 7.1 Channel Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "981-000748                                                    981-000750",
       "981-000748"

--- a/open-db/Headphones/a1eb288f-781b-475b-82b8-8a786e5e3a7d.json
+++ b/open-db/Headphones/a1eb288f-781b-475b-82b8-8a786e5e3a7d.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["981-000956"],
     "name": "Logitech Pro X Headset",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/a5d2df29-07ed-407c-9c5e-c1d7dc1d2b0d.json
+++ b/open-db/Headphones/a5d2df29-07ed-407c-9c5e-c1d7dc1d2b0d.json
@@ -2,7 +2,7 @@
   "opendb_id": "a5d2df29-07ed-407c-9c5e-c1d7dc1d2b0d",
   "metadata": {
     "name": "Logitech G435 Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-001049"]
   },
   "connection_types": [],

--- a/open-db/Headphones/ae7e0135-593b-4644-a77b-0151d75f5e08.json
+++ b/open-db/Headphones/ae7e0135-593b-4644-a77b-0151d75f5e08.json
@@ -2,7 +2,7 @@
   "opendb_id": "ae7e0135-593b-4644-a77b-0151d75f5e08",
   "metadata": {
     "name": "Logitech G432 7.1 Channel Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "981-000769                                                    981-000770",
       "981-000769"

--- a/open-db/Headphones/b5934daf-2e76-4a2b-a430-aaef86f79d66.json
+++ b/open-db/Headphones/b5934daf-2e76-4a2b-a430-aaef86f79d66.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["981-000811"],
     "name": "Logitech G PRO Headset",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/b73d723f-ea71-4810-a7cb-e0532212a69b.json
+++ b/open-db/Headphones/b73d723f-ea71-4810-a7cb-e0532212a69b.json
@@ -2,7 +2,7 @@
   "opendb_id": "b73d723f-ea71-4810-a7cb-e0532212a69b",
   "metadata": {
     "name": "Logitech PRO X 2 LIGHTSPEED Wireless Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "981-001268                                                    981-001270                                                    981-001269",
       "981-001268"

--- a/open-db/Headphones/b748c015-b8f9-41aa-b1c4-aa63e1babbd2.json
+++ b/open-db/Headphones/b748c015-b8f9-41aa-b1c4-aa63e1babbd2.json
@@ -2,7 +2,7 @@
   "opendb_id": "b748c015-b8f9-41aa-b1c4-aa63e1babbd2",
   "metadata": {
     "name": "Logitech G735 Wireless Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-001083", "981-001084", "981-001082"],
     "releaseYear": 2022
   },

--- a/open-db/Headphones/bb5f5434-535c-419c-95e9-fd8347b10491.json
+++ b/open-db/Headphones/bb5f5434-535c-419c-95e9-fd8347b10491.json
@@ -2,7 +2,7 @@
   "opendb_id": "bb5f5434-535c-419c-95e9-fd8347b10491",
   "metadata": {
     "name": "Logitech ASTRO A50 (GEN 5) Closed-Back Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": [
       "939-002217                                                    939-002224                                                    939-002225",
       "939-002217",

--- a/open-db/Headphones/beea6a9d-50f3-425c-89a7-04ee815a2d81.json
+++ b/open-db/Headphones/beea6a9d-50f3-425c-89a7-04ee815a2d81.json
@@ -2,7 +2,7 @@
   "opendb_id": "beea6a9d-50f3-425c-89a7-04ee815a2d81",
   "metadata": {
     "name": "Audio-Technica ATH-CK313MPK Closed-Back In-Ear Headphones with Microphone",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["ATH-CK313MPK", "939-001847"]
   },
   "connection_types": [],

--- a/open-db/Headphones/c6e1bf9a-0f5d-4b99-8e55-15a7c7a15c32.json
+++ b/open-db/Headphones/c6e1bf9a-0f5d-4b99-8e55-15a7c7a15c32.json
@@ -2,7 +2,7 @@
   "opendb_id": "c6e1bf9a-0f5d-4b99-8e55-15a7c7a15c32",
   "metadata": {
     "name": "Logitech G35 7.1 Channel Closed Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000116"]
   },
   "connection_types": [],

--- a/open-db/Headphones/dd9189a1-f3b8-4889-8377-c4f21232f582.json
+++ b/open-db/Headphones/dd9189a1-f3b8-4889-8377-c4f21232f582.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["981-001073"],
     "name": "Logitech G435 Headset",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connection_types": [],
   "ear_pad_material": [],

--- a/open-db/Headphones/ede15eb8-5198-4740-9a4e-acd8e9305db9.json
+++ b/open-db/Headphones/ede15eb8-5198-4740-9a4e-acd8e9305db9.json
@@ -2,7 +2,7 @@
   "opendb_id": "ede15eb8-5198-4740-9a4e-acd8e9305db9",
   "metadata": {
     "name": "Logitech G433 Black Open 7.1 Channel Gaming Headset",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["981-000668", "981-000708", "G433"]
   },
   "connection_types": [],

--- a/open-db/Keyboard/019778c7-ef1d-40e3-bc48-920a6d343ecc.json
+++ b/open-db/Keyboard/019778c7-ef1d-40e3-bc48-920a6d343ecc.json
@@ -2,7 +2,7 @@
   "opendb_id": "019778c7-ef1d-40e3-bc48-920a6d343ecc",
   "metadata": {
     "name": "Logitech G213 RGB Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009284"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/01b93c37-2331-4783-a650-d9b42b394a44.json
+++ b/open-db/Keyboard/01b93c37-2331-4783-a650-d9b42b394a44.json
@@ -2,7 +2,7 @@
   "opendb_id": "01b93c37-2331-4783-a650-d9b42b394a44",
   "metadata": {
     "name": "Logitech G413 SE Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010442", "920-010446"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/0320150e-8ec9-42bc-a573-11df6357a073.json
+++ b/open-db/Keyboard/0320150e-8ec9-42bc-a573-11df6357a073.json
@@ -2,7 +2,7 @@
   "opendb_id": "0320150e-8ec9-42bc-a573-11df6357a073",
   "metadata": {
     "name": "Logitech PRO X RGB Bluetooth/Wireless/Wired/Wired Logitech GX Blue Clicky Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012118"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/0738f7d9-b87e-42bf-8b42-e381e408991c.json
+++ b/open-db/Keyboard/0738f7d9-b87e-42bf-8b42-e381e408991c.json
@@ -2,7 +2,7 @@
   "opendb_id": "0738f7d9-b87e-42bf-8b42-e381e408991c",
   "metadata": {
     "name": "Logitech MK295 Silent Wireless/Wired Standard Keyboard with Optical Mouse",
-    "manufacturer": "YEYIAN",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009800", "YAT1806-EN"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/13cf8fac-eefc-45f6-9f18-910f092a7511.json
+++ b/open-db/Keyboard/13cf8fac-eefc-45f6-9f18-910f092a7511.json
@@ -2,7 +2,7 @@
   "opendb_id": "13cf8fac-eefc-45f6-9f18-910f092a7511",
   "metadata": {
     "name": "Logitech G915 TKL RGB Wireless/Bluetooth/Wired GL Linear Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009512"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/1967a87b-4bb5-47f7-ad97-959f52500554.json
+++ b/open-db/Keyboard/1967a87b-4bb5-47f7-ad97-959f52500554.json
@@ -2,7 +2,7 @@
   "opendb_id": "1967a87b-4bb5-47f7-ad97-959f52500554",
   "metadata": {
     "name": "Logitech G15 Wired Standard Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-000379"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/19f2207e-a57e-4f53-99ba-24216071849f.json
+++ b/open-db/Keyboard/19f2207e-a57e-4f53-99ba-24216071849f.json
@@ -2,7 +2,7 @@
   "opendb_id": "19f2207e-a57e-4f53-99ba-24216071849f",
   "metadata": {
     "name": "Logitech G Pro League of Legends RGB Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920010533", "920-010533"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/1db04d0f-c7e7-47b7-a9e0-098e5a4a5e3b.json
+++ b/open-db/Keyboard/1db04d0f-c7e7-47b7-a9e0-098e5a4a5e3b.json
@@ -2,7 +2,7 @@
   "opendb_id": "1db04d0f-c7e7-47b7-a9e0-098e5a4a5e3b",
   "metadata": {
     "name": "Logitech PRO X RAPID RGB Logitech Magnetic Analog Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-013133", "920-013254"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/1e34893b-2f99-4083-aedb-79f2bda23ee7.json
+++ b/open-db/Keyboard/1e34893b-2f99-4083-aedb-79f2bda23ee7.json
@@ -2,7 +2,7 @@
   "opendb_id": "1e34893b-2f99-4083-aedb-79f2bda23ee7",
   "metadata": {
     "name": "Logitech Pro X 60% Mini RGB Bluetooth/Wireless/Wired Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012164"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/25d4f1d1-2ec1-438f-9744-7156ce8755a0.json
+++ b/open-db/Keyboard/25d4f1d1-2ec1-438f-9744-7156ce8755a0.json
@@ -2,7 +2,7 @@
   "opendb_id": "25d4f1d1-2ec1-438f-9744-7156ce8755a0",
   "metadata": {
     "name": "Logitech PRO X RAPID RGB Logitech Magnetic Analog Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-013131", "920-013234"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/2f864c93-ac92-457c-9cce-439e5b3a4728.json
+++ b/open-db/Keyboard/2f864c93-ac92-457c-9cce-439e5b3a4728.json
@@ -2,7 +2,7 @@
   "opendb_id": "2f864c93-ac92-457c-9cce-439e5b3a4728",
   "metadata": {
     "name": "Logitech PRO X 60 RGB Bluetooth/Wireless/Wired Mini Logitech GX Brown Tactile Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-011921", "920-011935"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/354a51e1-1146-4ccc-8354-53716e5f0c71.json
+++ b/open-db/Keyboard/354a51e1-1146-4ccc-8354-53716e5f0c71.json
@@ -2,7 +2,7 @@
   "opendb_id": "354a51e1-1146-4ccc-8354-53716e5f0c71",
   "metadata": {
     "name": "Logitech G915 LIGHTSPEED TKL RGB Wireless/Wired/Bluetooth Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012753", "920-012738"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/3574a94b-afc1-40dc-8395-7bf5870bb7a5.json
+++ b/open-db/Keyboard/3574a94b-afc1-40dc-8395-7bf5870bb7a5.json
@@ -2,7 +2,7 @@
   "opendb_id": "3574a94b-afc1-40dc-8395-7bf5870bb7a5",
   "metadata": {
     "name": "Logitech G715 RGB Wired/Wireless/Bluetooth Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010656", "920-010665"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/358aba95-cdff-4a6b-b924-70febe792566.json
+++ b/open-db/Keyboard/358aba95-cdff-4a6b-b924-70febe792566.json
@@ -2,7 +2,7 @@
   "opendb_id": "358aba95-cdff-4a6b-b924-70febe792566",
   "metadata": {
     "name": "Logitech G915 X LIGHTSPEED RGB Low-Profile GL Tactile Wired/Wireless/Bluetooth Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012670", "920-012680"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/3a3d0df7-5c31-4194-838a-9d636242960a.json
+++ b/open-db/Keyboard/3a3d0df7-5c31-4194-838a-9d636242960a.json
@@ -2,7 +2,7 @@
   "opendb_id": "3a3d0df7-5c31-4194-838a-9d636242960a",
   "metadata": {
     "name": "Logitech PRO X 60 RGB Bluetooth/Wireless/Wired Mini Logitech GX Red Linear Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012169"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/3b862951-b2a9-4d2c-becb-9dfbd20ddaea.json
+++ b/open-db/Keyboard/3b862951-b2a9-4d2c-becb-9dfbd20ddaea.json
@@ -2,7 +2,7 @@
   "opendb_id": "3b862951-b2a9-4d2c-becb-9dfbd20ddaea",
   "metadata": {
     "name": "Logitech G413 SE Kailh LT Brown Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010555", "920-010433"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/3c25512a-2e4a-4f1f-90c6-32c2b3fd4cdf.json
+++ b/open-db/Keyboard/3c25512a-2e4a-4f1f-90c6-32c2b3fd4cdf.json
@@ -2,7 +2,7 @@
   "opendb_id": "3c25512a-2e4a-4f1f-90c6-32c2b3fd4cdf",
   "metadata": {
     "name": "Logitech G915 LIGHTSPEED TKL RGB Wireless/Wired/Bluetooth Logitech Low-Profile GL Tactile Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012732", "920-012748"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/3e3f0447-65dd-4b8e-8553-6356e867f903.json
+++ b/open-db/Keyboard/3e3f0447-65dd-4b8e-8553-6356e867f903.json
@@ -2,7 +2,7 @@
   "opendb_id": "3e3f0447-65dd-4b8e-8553-6356e867f903",
   "metadata": {
     "name": "Logitech G713 RGB Wired GX Brown Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010413"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/425b468d-6d4e-46fd-8d71-b0c44b404185.json
+++ b/open-db/Keyboard/425b468d-6d4e-46fd-8d71-b0c44b404185.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["920-008386"],
     "name": "Logitech G613 Lightspeed Wireless Mechanical Gaming Keyboard, Multihost 2.4 GHz + Blutooth Connectivity",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "features": [],

--- a/open-db/Keyboard/45c39195-e33e-4863-a800-766124e48e8b.json
+++ b/open-db/Keyboard/45c39195-e33e-4863-a800-766124e48e8b.json
@@ -2,7 +2,7 @@
   "opendb_id": "45c39195-e33e-4863-a800-766124e48e8b",
   "metadata": {
     "name": "Logitech G213 PRODIGY RGB Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-008083", "920-008096"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/47bcc3b9-2cca-4b93-9438-efb607bc9fe6.json
+++ b/open-db/Keyboard/47bcc3b9-2cca-4b93-9438-efb607bc9fe6.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["920-009176"],
     "name": "Logitech G815 RGB Mechanical Gaming Keyboard (Tactile)",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "features": [],

--- a/open-db/Keyboard/4a5d4339-9f6c-41ff-af8a-df7d14cba0ff.json
+++ b/open-db/Keyboard/4a5d4339-9f6c-41ff-af8a-df7d14cba0ff.json
@@ -2,7 +2,7 @@
   "opendb_id": "4a5d4339-9f6c-41ff-af8a-df7d14cba0ff",
   "metadata": {
     "name": "Logitech G515 LIGHTSPEED RGB Wireless/Bluetooth/Wired GL Linear V2 Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012536"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/5253de0f-86e9-4132-bc4c-9052aff596b2.json
+++ b/open-db/Keyboard/5253de0f-86e9-4132-bc4c-9052aff596b2.json
@@ -2,7 +2,7 @@
   "opendb_id": "5253de0f-86e9-4132-bc4c-9052aff596b2",
   "metadata": {
     "name": "Logitech G710 Plus Cherry MX Brown Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-003887"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/61d6afc7-de5d-4477-a2f6-2bea871f52d8.json
+++ b/open-db/Keyboard/61d6afc7-de5d-4477-a2f6-2bea871f52d8.json
@@ -2,7 +2,7 @@
   "opendb_id": "61d6afc7-de5d-4477-a2f6-2bea871f52d8",
   "metadata": {
     "name": "Logitech G515 LIGHTSPEED RGB Wireless/Bluetooth/Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012537"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/67e2ffac-a78f-4f19-be89-76d0a927f68f.json
+++ b/open-db/Keyboard/67e2ffac-a78f-4f19-be89-76d0a927f68f.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["920-009300"],
     "name": "Logitech G512 SE Lightsync RGB Mechanical Gaming Keyboard with USB Passthrough",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "features": [],

--- a/open-db/Keyboard/6a9dcae0-d383-4edb-860e-a6b6e20bdc85.json
+++ b/open-db/Keyboard/6a9dcae0-d383-4edb-860e-a6b6e20bdc85.json
@@ -2,7 +2,7 @@
   "opendb_id": "6a9dcae0-d383-4edb-860e-a6b6e20bdc85",
   "metadata": {
     "name": "Logitech G13 RGB Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-000946"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/6cd2b101-1ceb-42f5-8225-3a3de8a67bc3.json
+++ b/open-db/Keyboard/6cd2b101-1ceb-42f5-8225-3a3de8a67bc3.json
@@ -2,7 +2,7 @@
   "opendb_id": "6cd2b101-1ceb-42f5-8225-3a3de8a67bc3",
   "metadata": {
     "name": "Logitech G515 Mechanical LIGHTSPEED RGB Wireless/Bluetooth/Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012535", "920-012581", "920-012539"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/6e53fb27-be2d-4e84-a23f-17c9bb3ba934.json
+++ b/open-db/Keyboard/6e53fb27-be2d-4e84-a23f-17c9bb3ba934.json
@@ -2,7 +2,7 @@
   "opendb_id": "6e53fb27-be2d-4e84-a23f-17c9bb3ba934",
   "metadata": {
     "name": "Logitech G915 X Mechanical Gaming Keyboard LIGHTSPEED RGB Wired/Wireless/Bluetooth",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012685", "920-012691"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/75b9a1a4-4a1d-46f1-aecb-e851aa6f5ee2.json
+++ b/open-db/Keyboard/75b9a1a4-4a1d-46f1-aecb-e851aa6f5ee2.json
@@ -2,7 +2,7 @@
   "opendb_id": "75b9a1a4-4a1d-46f1-aecb-e851aa6f5ee2",
   "metadata": {
     "name": "Logitech G Pro X RGB Wired Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009229"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/77a00eba-72e6-4604-aa02-2c83e243a917.json
+++ b/open-db/Keyboard/77a00eba-72e6-4604-aa02-2c83e243a917.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["920-009103"],
     "name": "Redragon K551 Mechanical Gaming Keyboard with Cherry MX Blue Switches Vara 104 Keys Numpad Tactile USB Wired Computer Keyboard Steel Construction for Windows PC Games (Black RED LED Backlit)",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "features": [],

--- a/open-db/Keyboard/872a2f33-6dec-46b3-98a8-53e2d52f91af.json
+++ b/open-db/Keyboard/872a2f33-6dec-46b3-98a8-53e2d52f91af.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["920-008300"],
     "name": "Logitech G413 Backlit Mechanical Gaming Keyboard with USB Passthrough - Carbon",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "features": [],

--- a/open-db/Keyboard/8c1c2d85-f8e0-4ee6-b054-82b4e235ac2a.json
+++ b/open-db/Keyboard/8c1c2d85-f8e0-4ee6-b054-82b4e235ac2a.json
@@ -2,7 +2,7 @@
   "opendb_id": "8c1c2d85-f8e0-4ee6-b054-82b4e235ac2a",
   "metadata": {
     "name": "Logitech G815 RGB Wired Logitech GL Tactile Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-011354", "920-011359"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/927b5f36-8cf0-4690-91f5-6609ce7e46f4.json
+++ b/open-db/Keyboard/927b5f36-8cf0-4690-91f5-6609ce7e46f4.json
@@ -2,7 +2,7 @@
   "opendb_id": "927b5f36-8cf0-4690-91f5-6609ce7e46f4",
   "metadata": {
     "name": "Logitech G810 Orion Spectrum RGB Romer-G Tactile Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["G810", "920-007739"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/92a9a417-f8f3-41d9-a03f-197d1e83b64c.json
+++ b/open-db/Keyboard/92a9a417-f8f3-41d9-a03f-197d1e83b64c.json
@@ -2,7 +2,7 @@
   "opendb_id": "92a9a417-f8f3-41d9-a03f-197d1e83b64c",
   "metadata": {
     "name": "Logitech PRO X RGB Logitech GX Red Linear Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012122"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/98159bbf-83c4-4dbe-a0a8-bf00df5ba5ec.json
+++ b/open-db/Keyboard/98159bbf-83c4-4dbe-a0a8-bf00df5ba5ec.json
@@ -2,7 +2,7 @@
   "opendb_id": "98159bbf-83c4-4dbe-a0a8-bf00df5ba5ec",
   "metadata": {
     "name": "Logitech G713 RGB Wired Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010670"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/9d8d030c-e917-4950-80fb-a893398b0c31.json
+++ b/open-db/Keyboard/9d8d030c-e917-4950-80fb-a893398b0c31.json
@@ -2,7 +2,7 @@
   "opendb_id": "9d8d030c-e917-4950-80fb-a893398b0c31",
   "metadata": {
     "name": "Logitech G515 LIGHTSPEED RGB GL Tactile V2 Wireless/Bluetooth/Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012423", "920-012580", "920-012538"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/a0a01b9e-e9fe-47dc-a8b6-5b64d55c7258.json
+++ b/open-db/Keyboard/a0a01b9e-e9fe-47dc-a8b6-5b64d55c7258.json
@@ -2,7 +2,7 @@
   "opendb_id": "a0a01b9e-e9fe-47dc-a8b6-5b64d55c7258",
   "metadata": {
     "name": "Logitech G915 TKL RGB Wireless/Bluetooth/Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009529"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/a0e24378-e1ca-4b2b-9a64-384bb4a71aa1.json
+++ b/open-db/Keyboard/a0e24378-e1ca-4b2b-9a64-384bb4a71aa1.json
@@ -2,7 +2,7 @@
   "opendb_id": "a0e24378-e1ca-4b2b-9a64-384bb4a71aa1",
   "metadata": {
     "name": "Logitech G915 X LIGHTSPEED RGB Wired/Wireless/Bluetooth Logitech Low-Profile GL Linear Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012696", "920-012699"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/a1ede029-a8e7-418d-b0bf-d5fb9d73d605.json
+++ b/open-db/Keyboard/a1ede029-a8e7-418d-b0bf-d5fb9d73d605.json
@@ -2,7 +2,7 @@
   "opendb_id": "a1ede029-a8e7-418d-b0bf-d5fb9d73d605",
   "metadata": {
     "name": "Logitech G Pro X Shroud RGB Wired Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009846"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/a2b02399-8cf2-4ae8-b1f0-a8f94193bc7e.json
+++ b/open-db/Keyboard/a2b02399-8cf2-4ae8-b1f0-a8f94193bc7e.json
@@ -2,7 +2,7 @@
   "opendb_id": "a2b02399-8cf2-4ae8-b1f0-a8f94193bc7e",
   "metadata": {
     "name": "Logitech G915 X RGB Wired Logitech GL Tactile Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012937", "920-012944"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/a495e8ce-1878-4506-9ca2-6dde9395ddc8.json
+++ b/open-db/Keyboard/a495e8ce-1878-4506-9ca2-6dde9395ddc8.json
@@ -2,7 +2,7 @@
   "opendb_id": "a495e8ce-1878-4506-9ca2-6dde9395ddc8",
   "metadata": {
     "name": "Logitech G815 Lightsync RGB Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009000", "G815"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/aba65cf6-7872-46fb-9a9b-e7ecd30bc9fe.json
+++ b/open-db/Keyboard/aba65cf6-7872-46fb-9a9b-e7ecd30bc9fe.json
@@ -2,7 +2,7 @@
   "opendb_id": "aba65cf6-7872-46fb-9a9b-e7ecd30bc9fe",
   "metadata": {
     "name": "Logitech Pro X Wireless/Wired RGB Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012143"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/b3c88071-e211-42be-bdbf-f25eb00cc1c8.json
+++ b/open-db/Keyboard/b3c88071-e211-42be-bdbf-f25eb00cc1c8.json
@@ -2,7 +2,7 @@
   "opendb_id": "b3c88071-e211-42be-bdbf-f25eb00cc1c8",
   "metadata": {
     "name": "Logitech G PRO Wired Gaming Tenkeyless Keyboard, Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009396", "920-013131"],
     "releaseYear": 2017
   },

--- a/open-db/Keyboard/c1308eae-2c56-4433-b480-b9ce97edb746.json
+++ b/open-db/Keyboard/c1308eae-2c56-4433-b480-b9ce97edb746.json
@@ -2,7 +2,7 @@
   "opendb_id": "c1308eae-2c56-4433-b480-b9ce97edb746",
   "metadata": {
     "name": "Logitech PRO X RGB Logitech GX Brown Tactile Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012127"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/c13dd87d-2912-46d0-ae1c-c8b5870303ca.json
+++ b/open-db/Keyboard/c13dd87d-2912-46d0-ae1c-c8b5870303ca.json
@@ -2,7 +2,7 @@
   "opendb_id": "c13dd87d-2912-46d0-ae1c-c8b5870303ca",
   "metadata": {
     "name": "Logitech G915 TKL RGB GL Tactile Wireless/Bluetooth/Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009660"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/c18ac125-a398-4241-ad45-182f85f19402.json
+++ b/open-db/Keyboard/c18ac125-a398-4241-ad45-182f85f19402.json
@@ -2,7 +2,7 @@
   "opendb_id": "c18ac125-a398-4241-ad45-182f85f19402",
   "metadata": {
     "name": "Logitech G19s Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-004985"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/c29a4f10-1dc0-4cca-bb27-97eb5803aee3.json
+++ b/open-db/Keyboard/c29a4f10-1dc0-4cca-bb27-97eb5803aee3.json
@@ -2,7 +2,7 @@
   "opendb_id": "c29a4f10-1dc0-4cca-bb27-97eb5803aee3",
   "metadata": {
     "name": "Logitech G105 Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-003371"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/c5301217-6ef3-4997-ab40-4e73af24d6bb.json
+++ b/open-db/Keyboard/c5301217-6ef3-4997-ab40-4e73af24d6bb.json
@@ -2,7 +2,7 @@
   "opendb_id": "c5301217-6ef3-4997-ab40-4e73af24d6bb",
   "metadata": {
     "name": "Logitech G910 Orion Spark RGB Wired Romer-G Tactile Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-006385"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/c53698d6-fd48-435b-af91-98877d5aa81e.json
+++ b/open-db/Keyboard/c53698d6-fd48-435b-af91-98877d5aa81e.json
@@ -2,7 +2,7 @@
   "opendb_id": "c53698d6-fd48-435b-af91-98877d5aa81e",
   "metadata": {
     "name": "Logitech G715 RGB Wired/Wireless/Bluetooth GX Red Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010684"],
     "releaseYear": 2022
   },

--- a/open-db/Keyboard/c9762366-d418-4d77-96f0-bf486f3f7bd7.json
+++ b/open-db/Keyboard/c9762366-d418-4d77-96f0-bf486f3f7bd7.json
@@ -2,7 +2,7 @@
   "opendb_id": "c9762366-d418-4d77-96f0-bf486f3f7bd7",
   "metadata": {
     "name": "Logitech G915 TKL RGB Wireless/Bluetooth/Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009495"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/cb183834-e339-457c-967d-fdcf8d409edb.json
+++ b/open-db/Keyboard/cb183834-e339-457c-967d-fdcf8d409edb.json
@@ -2,7 +2,7 @@
   "opendb_id": "cb183834-e339-457c-967d-fdcf8d409edb",
   "metadata": {
     "name": "Logitech G915 Lightspeed RGB Wireless Logitech GL Tactile Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-008902", "920-008910"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/cb78a417-fe16-499e-bd0c-df414c061b8a.json
+++ b/open-db/Keyboard/cb78a417-fe16-499e-bd0c-df414c061b8a.json
@@ -2,7 +2,7 @@
   "opendb_id": "cb78a417-fe16-499e-bd0c-df414c061b8a",
   "metadata": {
     "name": "Logitech G915 X RGB Wired Logitech GL Linear Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012950"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/cb8cbcaf-a190-41c6-a1fc-1a6c8642b69d.json
+++ b/open-db/Keyboard/cb8cbcaf-a190-41c6-a1fc-1a6c8642b69d.json
@@ -2,7 +2,7 @@
   "opendb_id": "cb8cbcaf-a190-41c6-a1fc-1a6c8642b69d",
   "metadata": {
     "name": "Logitech G715 RGB Wired/Wireless/Bluetooth Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010453", "920-010465", "920-010467"]
   },
   "connectivity": ["Wired"],

--- a/open-db/Keyboard/cdcab5c6-b4b9-4662-bfbc-fb1f5025ead1.json
+++ b/open-db/Keyboard/cdcab5c6-b4b9-4662-bfbc-fb1f5025ead1.json
@@ -2,7 +2,7 @@
   "opendb_id": "cdcab5c6-b4b9-4662-bfbc-fb1f5025ead1",
   "metadata": {
     "name": "Logitech G710 Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-006519"]
   },
   "connectivity": ["Wired USB-A"],

--- a/open-db/Keyboard/d52ec8e9-0d01-4604-8e57-19736fe9a93d.json
+++ b/open-db/Keyboard/d52ec8e9-0d01-4604-8e57-19736fe9a93d.json
@@ -2,7 +2,7 @@
   "opendb_id": "d52ec8e9-0d01-4604-8e57-19736fe9a93d",
   "metadata": {
     "name": "Logitech K120 Wired Standard Keyboard",
-    "manufacturer": "Pantheon",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-002478", "920-002479", "TLG-GRY", "K120 Wired Keyboard - Black"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/db37ee4f-6c1f-444a-81af-8ed8083aec3d.json
+++ b/open-db/Keyboard/db37ee4f-6c1f-444a-81af-8ed8083aec3d.json
@@ -2,7 +2,7 @@
   "opendb_id": "db37ee4f-6c1f-444a-81af-8ed8083aec3d",
   "metadata": {
     "name": "Logitech PRO X RAPID RGB Logitech Magnetic Analog Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-013132", "920-013243"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/dca296cf-f974-45fb-bb24-0ca76df6265c.json
+++ b/open-db/Keyboard/dca296cf-f974-45fb-bb24-0ca76df6265c.json
@@ -2,7 +2,7 @@
   "opendb_id": "dca296cf-f974-45fb-bb24-0ca76df6265c",
   "metadata": {
     "name": "Logitech G713 RGB GX Blue Wired Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-010642"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/e2e73946-e58c-4acc-9567-fad5b636eaf2.json
+++ b/open-db/Keyboard/e2e73946-e58c-4acc-9567-fad5b636eaf2.json
@@ -2,7 +2,7 @@
   "opendb_id": "e2e73946-e58c-4acc-9567-fad5b636eaf2",
   "metadata": {
     "name": "Logitech G513 Carbon RGB Wired GX Blue Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-008924", "920-009287", "920-008287"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/e6df44f2-dd29-4b8f-98b0-2919c3380734.json
+++ b/open-db/Keyboard/e6df44f2-dd29-4b8f-98b0-2919c3380734.json
@@ -2,7 +2,7 @@
   "opendb_id": "e6df44f2-dd29-4b8f-98b0-2919c3380734",
   "metadata": {
     "name": "Logitech G915 X LIGHTSPEED RGB Wired/Wireless/Bluetooth Mechanical Gaming Keyboard with GL Clicky",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012704", "920-012710"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/eb07789b-b4ff-4d7c-8e27-3f53a6d11b77.json
+++ b/open-db/Keyboard/eb07789b-b4ff-4d7c-8e27-3f53a6d11b77.json
@@ -2,7 +2,7 @@
   "opendb_id": "eb07789b-b4ff-4d7c-8e27-3f53a6d11b77",
   "metadata": {
     "name": "Logitech G915 LIGHTSPEED TKL RGB Wireless/Wired/Bluetooth Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012715", "920-012726"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/ee56ced7-ec28-40ac-9488-879406df35a5.json
+++ b/open-db/Keyboard/ee56ced7-ec28-40ac-9488-879406df35a5.json
@@ -2,7 +2,7 @@
   "opendb_id": "ee56ced7-ec28-40ac-9488-879406df35a5",
   "metadata": {
     "name": "Logitech G915 LIGHTSPEED TKL RGB Wireless/Wired/Bluetooth Logitech Low-Profile GL Linear Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012743", "920-012758"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/eeb1a7d6-190f-4687-9975-96996c814c61.json
+++ b/open-db/Keyboard/eeb1a7d6-190f-4687-9975-96996c814c61.json
@@ -2,7 +2,7 @@
   "opendb_id": "eeb1a7d6-190f-4687-9975-96996c814c61",
   "metadata": {
     "name": "Logitech G515 RGB Wired GL Tactile Mechanical Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-012868", "920-012912"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/f11ba438-6dd8-40de-99f3-333c25081a90.json
+++ b/open-db/Keyboard/f11ba438-6dd8-40de-99f3-333c25081a90.json
@@ -2,7 +2,7 @@
   "opendb_id": "f11ba438-6dd8-40de-99f3-333c25081a90",
   "metadata": {
     "name": "Logitech G915 Lightspeed RGB Wireless Logitech GL Clicky Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009103", "920-009111"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/f61e8122-4994-4d0e-8904-a214e6f89be3.json
+++ b/open-db/Keyboard/f61e8122-4994-4d0e-8904-a214e6f89be3.json
@@ -2,7 +2,7 @@
   "opendb_id": "f61e8122-4994-4d0e-8904-a214e6f89be3",
   "metadata": {
     "name": "Logitech G513 Carbon Mechanical RGB Gaming Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-009322", "G513"]
   },
   "connectivity": [],

--- a/open-db/Keyboard/fc3d58e1-73d6-466d-902e-8e1fb2d9c162.json
+++ b/open-db/Keyboard/fc3d58e1-73d6-466d-902e-8e1fb2d9c162.json
@@ -2,7 +2,7 @@
   "opendb_id": "fc3d58e1-73d6-466d-902e-8e1fb2d9c162",
   "metadata": {
     "name": "Logitech PRO X 60 RGB Bluetooth/Wireless/Wired Mini Keyboard",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["920-011902", "920-011916"]
   },
   "connectivity": [],

--- a/open-db/Microphone/1fc77f0b-4564-42a2-943c-d0d5e7f9ba49.json
+++ b/open-db/Microphone/1fc77f0b-4564-42a2-943c-d0d5e7f9ba49.json
@@ -2,7 +2,7 @@
   "opendb_id": "1fc77f0b-4564-42a2-943c-d0d5e7f9ba49",
   "metadata": {
     "name": "Blue Snowball iCE USB Microphone - White",
-    "manufacturer": "Logitech for Creators",
+    "manufacturer": "Logitech",
     "part_numbers": ["988-000071"]
   },
   "connectivity_type": ["USB-A"],

--- a/open-db/Mouse/01442b68-018a-4922-82f4-a71b794d599c.json
+++ b/open-db/Mouse/01442b68-018a-4922-82f4-a71b794d599c.json
@@ -2,7 +2,7 @@
   "opendb_id": "01442b68-018a-4922-82f4-a71b794d599c",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse, White + Yeti Orb RGB Gaming Microphone with LIGHTSYNC, USB Mic for Streaming",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/064d7d6e-ee2c-4aea-bd4b-045b4c28aeb2.json
+++ b/open-db/Mouse/064d7d6e-ee2c-4aea-bd4b-045b4c28aeb2.json
@@ -2,7 +2,7 @@
   "opendb_id": "064d7d6e-ee2c-4aea-bd4b-045b4c28aeb2",
   "metadata": {
     "name": "Logitech G Pro Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-004855"]
   },
   "connectivity": [],

--- a/open-db/Mouse/091dacc9-3d0f-4f24-bd1a-d6b2d7606fa1.json
+++ b/open-db/Mouse/091dacc9-3d0f-4f24-bd1a-d6b2d7606fa1.json
@@ -2,7 +2,7 @@
   "opendb_id": "091dacc9-3d0f-4f24-bd1a-d6b2d7606fa1",
   "metadata": {
     "name": "Logitech G203 Lightsync Wired Optical Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005851"]
   },
   "connectivity": [],

--- a/open-db/Mouse/0ae52ef0-e0c2-4121-8333-8018ab8d0362.json
+++ b/open-db/Mouse/0ae52ef0-e0c2-4121-8333-8018ab8d0362.json
@@ -2,7 +2,7 @@
   "opendb_id": "0ae52ef0-e0c2-4121-8333-8018ab8d0362",
   "metadata": {
     "name": "Logitech G102 LIGHTSYNC RGB White Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005803", "Light Sync"]
   },
   "connectivity": [],

--- a/open-db/Mouse/0d87832e-dcd2-48c7-8feb-7ab831edf7dc.json
+++ b/open-db/Mouse/0d87832e-dcd2-48c7-8feb-7ab831edf7dc.json
@@ -2,7 +2,7 @@
   "opendb_id": "0d87832e-dcd2-48c7-8feb-7ab831edf7dc",
   "metadata": {
     "name": "Logitech G700s Laser Wireless Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-003584", "FBA_910-003584"]
   },
   "connectivity": [],

--- a/open-db/Mouse/0e3647e1-5451-4b5d-8ac8-dbcd0a5c77a7.json
+++ b/open-db/Mouse/0e3647e1-5451-4b5d-8ac8-dbcd0a5c77a7.json
@@ -2,7 +2,7 @@
   "opendb_id": "0e3647e1-5451-4b5d-8ac8-dbcd0a5c77a7",
   "metadata": {
     "name": "Logitech G603 Optical Wireless Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005099", "910-005101", "910-005102", "910-005100"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/0e756c23-e3db-4b04-9c23-875355f4734b.json
+++ b/open-db/Mouse/0e756c23-e3db-4b04-9c23-875355f4734b.json
@@ -2,7 +2,7 @@
   "opendb_id": "0e756c23-e3db-4b04-9c23-875355f4734b",
   "metadata": {
     "name": "Logitech G705 Wireless/Wired/Bluetooth Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006365"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/0eef627a-279a-4dbd-8189-73936a0373ff.json
+++ b/open-db/Mouse/0eef627a-279a-4dbd-8189-73936a0373ff.json
@@ -2,7 +2,7 @@
   "opendb_id": "0eef627a-279a-4dbd-8189-73936a0373ff",
   "metadata": {
     "name": "Logitech G102 LIGHTSYNC RGB Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005802"]
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/10b7bebc-abe1-476d-8527-a69da5eeefd2.json
+++ b/open-db/Mouse/10b7bebc-abe1-476d-8527-a69da5eeefd2.json
@@ -2,7 +2,7 @@
   "opendb_id": "10b7bebc-abe1-476d-8527-a69da5eeefd2",
   "metadata": {
     "name": "Logitech G309 LIGHTSPEED Wireless/Bluetooth Optical Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007205", "910-007207", "910-007209"]
   },
   "connectivity": [],

--- a/open-db/Mouse/11670211-2748-4c91-bc24-5bab55d746f2.json
+++ b/open-db/Mouse/11670211-2748-4c91-bc24-5bab55d746f2.json
@@ -2,7 +2,7 @@
   "opendb_id": "11670211-2748-4c91-bc24-5bab55d746f2",
   "metadata": {
     "name": "Logitech G502 Hero Wired Gaming Mouse + G440 Hard Gaming Mouse Pad Bundle - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/1310eda9-c2aa-482c-9c42-6ad1496c772a.json
+++ b/open-db/Mouse/1310eda9-c2aa-482c-9c42-6ad1496c772a.json
@@ -2,7 +2,7 @@
   "opendb_id": "1310eda9-c2aa-482c-9c42-6ad1496c772a",
   "metadata": {
     "name": "Logitech G305 LIGHTSPEED Wireless Gaming Mouse Lilac",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006020"],
     "series": "LIGHTSPEED",
     "variant": "G305 Lilac",

--- a/open-db/Mouse/143af760-1da2-40f0-ab81-7221cb98626a.json
+++ b/open-db/Mouse/143af760-1da2-40f0-ab81-7221cb98626a.json
@@ -2,7 +2,7 @@
   "opendb_id": "143af760-1da2-40f0-ab81-7221cb98626a",
   "metadata": {
     "name": "Pro X Superlight 2c Wireless Gaming Mouse: 51g Compact Mini Size, Symmetrical Shape, <8 kHz Polling, 44K DPI, PowerPlay Wireless Charging Supported, USB-C, 5 Programmable Buttons, For PC/Mac - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007518"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/166d3ac6-6da8-43fa-8417-2c820916f151.json
+++ b/open-db/Mouse/166d3ac6-6da8-43fa-8417-2c820916f151.json
@@ -2,7 +2,7 @@
   "opendb_id": "166d3ac6-6da8-43fa-8417-2c820916f151",
   "metadata": {
     "name": "Logitech G703 LIGHTSPEED Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005638"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/17d39a0a-6d6a-408d-9701-ee6d5a3260a9.json
+++ b/open-db/Mouse/17d39a0a-6d6a-408d-9701-ee6d5a3260a9.json
@@ -2,7 +2,7 @@
   "opendb_id": "17d39a0a-6d6a-408d-9701-ee6d5a3260a9",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse, Blue + Yeti Orb RGB Gaming Microphone with LIGHTSYNC, USB Mic for Streaming",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/182f5486-b720-4fb6-8c00-41519b71ba0f.json
+++ b/open-db/Mouse/182f5486-b720-4fb6-8c00-41519b71ba0f.json
@@ -2,7 +2,7 @@
   "opendb_id": "182f5486-b720-4fb6-8c00-41519b71ba0f",
   "metadata": {
     "name": "Logitech G Pro Wireless 2 Gaming Mouse + Powerplay 2 Wireless Chargining Mouse Pad Bundle - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/19377571-877c-41a4-81cc-43ca813cf646.json
+++ b/open-db/Mouse/19377571-877c-41a4-81cc-43ca813cf646.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["910-005472", "910-005470", "910-005471", "910-005469"],
     "name": "Logitech G502 HERO Wired Optical Mouse - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "series": "G",
     "variant": "502 HERO",
     "releaseYear": 2018

--- a/open-db/Mouse/1c930386-d239-4d09-b083-f00270c004c9.json
+++ b/open-db/Mouse/1c930386-d239-4d09-b083-f00270c004c9.json
@@ -2,7 +2,7 @@
   "opendb_id": "1c930386-d239-4d09-b083-f00270c004c9",
   "metadata": {
     "name": "Logitech G413 SE Mechanical Gaming Keyboard and Logitech G502 HERO High Performance Gaming Mouse Bundle",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/219fa5f1-f2c6-4ac0-8e99-72654a09600a.json
+++ b/open-db/Mouse/219fa5f1-f2c6-4ac0-8e99-72654a09600a.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["910-004360"],
     "name": "Logitech G300s Optical Ambidextrous  Gaming Mouse - 9 Programmable Buttons, Onboard Memory",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "lighting": [],

--- a/open-db/Mouse/2239f4a3-e037-4cde-a51c-a1eefce9ca77.json
+++ b/open-db/Mouse/2239f4a3-e037-4cde-a51c-a1eefce9ca77.json
@@ -2,7 +2,7 @@
   "opendb_id": "2239f4a3-e037-4cde-a51c-a1eefce9ca77",
   "metadata": {
     "name": "Logitech G309 Kamisato Ayaka Special Edition Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mouse Pad Bundle",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/26470c0f-2807-4afc-8a4f-1f5956096942.json
+++ b/open-db/Mouse/26470c0f-2807-4afc-8a4f-1f5956096942.json
@@ -2,7 +2,7 @@
   "opendb_id": "26470c0f-2807-4afc-8a4f-1f5956096942",
   "metadata": {
     "name": "Logitech G305 LIGHTSPEED Wireless/Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006376", "910-006378", "910-006377"]
   },
   "connectivity": [],

--- a/open-db/Mouse/2a56848d-9394-40c4-952c-dd9e930e2685.json
+++ b/open-db/Mouse/2a56848d-9394-40c4-952c-dd9e930e2685.json
@@ -2,7 +2,7 @@
   "opendb_id": "2a56848d-9394-40c4-952c-dd9e930e2685",
   "metadata": {
     "name": "Logitech G Pro Wireless/Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005270", "910-005272", "910-005271"]
   },
   "connectivity": [],

--- a/open-db/Mouse/2d10bd3f-17f5-4fe0-a278-a1b316ead27a.json
+++ b/open-db/Mouse/2d10bd3f-17f5-4fe0-a278-a1b316ead27a.json
@@ -2,7 +2,7 @@
   "opendb_id": "2d10bd3f-17f5-4fe0-a278-a1b316ead27a",
   "metadata": {
     "name": "Logitech V470 Bluetooth Laser Mouse",
-    "manufacturer": "Jaybird",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-000298"]
   },
   "connectivity": [],

--- a/open-db/Mouse/2f006742-2744-4356-8065-7e60311816cc.json
+++ b/open-db/Mouse/2f006742-2744-4356-8065-7e60311816cc.json
@@ -2,7 +2,7 @@
   "opendb_id": "2f006742-2744-4356-8065-7e60311816cc",
   "metadata": {
     "name": "Logitech G203 Lightsync Optical Wired Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005790"],
     "releaseYear": 2020
   },

--- a/open-db/Mouse/330002ea-b9b0-4f07-bd11-8ff76c32dd02.json
+++ b/open-db/Mouse/330002ea-b9b0-4f07-bd11-8ff76c32dd02.json
@@ -2,7 +2,7 @@
   "opendb_id": "330002ea-b9b0-4f07-bd11-8ff76c32dd02",
   "metadata": {
     "name": "Logitech PRO 2 LIGHTSPEED Wired/Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007290", "910-007302"]
   },
   "connectivity": [],

--- a/open-db/Mouse/36241cc6-14c3-4cfe-98ea-55dffed2bbc2.json
+++ b/open-db/Mouse/36241cc6-14c3-4cfe-98ea-55dffed2bbc2.json
@@ -2,7 +2,7 @@
   "opendb_id": "36241cc6-14c3-4cfe-98ea-55dffed2bbc2",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse (Mint) + G515 TKL Wireless Gaming Keyboard (Tactile, White) Bundle",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz", "Wired"],

--- a/open-db/Mouse/39e136a6-3bda-45a6-901d-e7321a7698f7.json
+++ b/open-db/Mouse/39e136a6-3bda-45a6-901d-e7321a7698f7.json
@@ -2,7 +2,7 @@
   "opendb_id": "39e136a6-3bda-45a6-901d-e7321a7698f7",
   "metadata": {
     "name": "Logitech G400 Optical Wired Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-002277"]
   },
   "connectivity": [],

--- a/open-db/Mouse/3b3bf456-d501-45d5-9190-9a1d2fa8f704.json
+++ b/open-db/Mouse/3b3bf456-d501-45d5-9190-9a1d2fa8f704.json
@@ -2,7 +2,7 @@
   "opendb_id": "3b3bf456-d501-45d5-9190-9a1d2fa8f704",
   "metadata": {
     "name": "Pro X Superlight 2c Wireless Gaming Mouse: 51g Compact Mini Size, Symmetrical Shape, <8 kHz Polling, 44K DPI, PowerPlay Wireless Charging Supported, USB-C, 5 Programmable Buttons, For PC/Mac - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007528"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/3b5ed0bd-b3e0-4de1-9338-660a5e828a20.json
+++ b/open-db/Mouse/3b5ed0bd-b3e0-4de1-9338-660a5e828a20.json
@@ -2,7 +2,7 @@
   "opendb_id": "3b5ed0bd-b3e0-4de1-9338-660a5e828a20",
   "metadata": {
     "name": "Logitech G502 Lightspeed Wireless Gaming Mouse with Lightsync RGB - Black Logitech G640 Large Cloth Gaming Mouse Pad, Optimized for Gaming Sensors Mac and PC Gaming Accessories",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["G502"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/3d9d6a52-7244-4446-845c-2408b23ab5be.json
+++ b/open-db/Mouse/3d9d6a52-7244-4446-845c-2408b23ab5be.json
@@ -2,7 +2,7 @@
   "opendb_id": "3d9d6a52-7244-4446-845c-2408b23ab5be",
   "metadata": {
     "name": "Logitech G502 X Plus Lightspeed Wireless Gaming Mouse + G733 Lightspeed Wireless Gaming Headset - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/3d9e96f7-dbb7-4fdb-9737-8a1fca68ff34.json
+++ b/open-db/Mouse/3d9e96f7-dbb7-4fdb-9737-8a1fca68ff34.json
@@ -2,7 +2,7 @@
   "opendb_id": "3d9e96f7-dbb7-4fdb-9737-8a1fca68ff34",
   "metadata": {
     "name": "Logitech G502 X Wireless and Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006178"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/3e784739-adc9-4069-817b-5e1a8acbf3ca.json
+++ b/open-db/Mouse/3e784739-adc9-4069-817b-5e1a8acbf3ca.json
@@ -2,7 +2,7 @@
   "opendb_id": "3e784739-adc9-4069-817b-5e1a8acbf3ca",
   "metadata": {
     "name": "Logitech G PRO Hero Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005439"]
   },
   "connectivity": [],

--- a/open-db/Mouse/3f389f80-7dab-4e1f-b35f-5e2d9ec80e23.json
+++ b/open-db/Mouse/3f389f80-7dab-4e1f-b35f-5e2d9ec80e23.json
@@ -2,7 +2,7 @@
   "opendb_id": "3f389f80-7dab-4e1f-b35f-5e2d9ec80e23",
   "metadata": {
     "name": "Logitech MX518 Wired Optical Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005542"]
   },
   "connectivity": [],

--- a/open-db/Mouse/3fba3405-af80-473d-9ea0-306cee0f06fe.json
+++ b/open-db/Mouse/3fba3405-af80-473d-9ea0-306cee0f06fe.json
@@ -2,7 +2,7 @@
   "opendb_id": "3fba3405-af80-473d-9ea0-306cee0f06fe",
   "metadata": {
     "name": "Logitech G Pro Wireless 2 Gaming Mouse + Powerplay 2 Wireless Chargining Mouse Pad Bundle - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/415344dc-29ab-4876-b001-929e881af0f4.json
+++ b/open-db/Mouse/415344dc-29ab-4876-b001-929e881af0f4.json
@@ -2,7 +2,7 @@
   "opendb_id": "415344dc-29ab-4876-b001-929e881af0f4",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse, Mint + Yeti Orb RGB Gaming Microphone with LIGHTSYNC, USB Mic for Streaming",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["G305"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/4544954d-88f8-4f9e-b9b2-0e0a5f70cc12.json
+++ b/open-db/Mouse/4544954d-88f8-4f9e-b9b2-0e0a5f70cc12.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "name": "Logitech PRO X2 SUPERSTRIKE Lightspeed Wireless Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007700"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C", "Wired"],

--- a/open-db/Mouse/46a1c62d-b72d-47cc-adc2-966743943031.json
+++ b/open-db/Mouse/46a1c62d-b72d-47cc-adc2-966743943031.json
@@ -2,7 +2,7 @@
   "opendb_id": "46a1c62d-b72d-47cc-adc2-966743943031",
   "metadata": {
     "name": "Logitech G502 X Plus Lightspeed Wireless Gaming Mouse + G515 TKL Wireless Gaming Keyboard (Tactile) Bundle: White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/47274145-43d1-4b5e-a5b0-26378ad905d3.json
+++ b/open-db/Mouse/47274145-43d1-4b5e-a5b0-26378ad905d3.json
@@ -2,7 +2,7 @@
   "opendb_id": "47274145-43d1-4b5e-a5b0-26378ad905d3",
   "metadata": {
     "name": "Logitech M325c Himalayan Fern Wireless Optical Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005658"]
   },
   "connectivity": [],

--- a/open-db/Mouse/499caee3-0d70-4295-b8e5-d14d29dd6146.json
+++ b/open-db/Mouse/499caee3-0d70-4295-b8e5-d14d29dd6146.json
@@ -2,7 +2,7 @@
   "opendb_id": "499caee3-0d70-4295-b8e5-d14d29dd6146",
   "metadata": {
     "name": "Logitech G PRO X Superlight 2 SE Wireless Gaming Mouse, 60 g pro-Grade Mouse with 5 programmable Buttons, 44K DPI Sensor, 888+ IPS, 1 kHz Report Rate, USB-C Charging for PC/Mac - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007646"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/4dde4506-35cf-4bf8-aa89-5aa4252e4fc4.json
+++ b/open-db/Mouse/4dde4506-35cf-4bf8-aa89-5aa4252e4fc4.json
@@ -2,7 +2,7 @@
   "opendb_id": "4dde4506-35cf-4bf8-aa89-5aa4252e4fc4",
   "metadata": {
     "name": "Logitech G502 X Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mouse Pad Bundle - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/4e68f43f-d3bf-41d9-a093-8c118bfc90fb.json
+++ b/open-db/Mouse/4e68f43f-d3bf-41d9-a093-8c118bfc90fb.json
@@ -2,7 +2,7 @@
   "opendb_id": "4e68f43f-d3bf-41d9-a093-8c118bfc90fb",
   "metadata": {
     "name": "Logitech G502 X Lightspeed Wireless Gaming Mouse + G515 TKL Wireless Gaming Keyboard (Tactile) Bundle: White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/4e760879-de33-47df-9d04-a15bcedec6c3.json
+++ b/open-db/Mouse/4e760879-de33-47df-9d04-a15bcedec6c3.json
@@ -2,7 +2,7 @@
   "opendb_id": "4e760879-de33-47df-9d04-a15bcedec6c3",
   "metadata": {
     "name": "Logitech PRO X SUPERLIGHT 2 DEX Wired/Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007371", "910-007373"]
   },
   "connectivity": [],

--- a/open-db/Mouse/4fe8ef6f-9c06-47d4-86dc-cbc1efd222c3.json
+++ b/open-db/Mouse/4fe8ef6f-9c06-47d4-86dc-cbc1efd222c3.json
@@ -2,7 +2,7 @@
   "opendb_id": "4fe8ef6f-9c06-47d4-86dc-cbc1efd222c3",
   "metadata": {
     "name": "Logitech G305 LIGHTSPEED Wireless Optical Gaming Mouse Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005280"],
     "variant": "G305 Black",
     "series": "LIGHTSPEED",

--- a/open-db/Mouse/526c190d-5f73-4e3e-bfd7-5cf34de43e4f.json
+++ b/open-db/Mouse/526c190d-5f73-4e3e-bfd7-5cf34de43e4f.json
@@ -2,7 +2,7 @@
   "opendb_id": "526c190d-5f73-4e3e-bfd7-5cf34de43e4f",
   "metadata": {
     "name": "Logitech G502 X Plus Wired and Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006169"]
   },
   "connectivity": [],

--- a/open-db/Mouse/5557e99c-64ba-415f-a843-8d6948b250d3.json
+++ b/open-db/Mouse/5557e99c-64ba-415f-a843-8d6948b250d3.json
@@ -2,7 +2,7 @@
   "opendb_id": "5557e99c-64ba-415f-a843-8d6948b250d3",
   "metadata": {
     "name": "Logitech G502 X Plus LIGHTSPEED Wireless RGB Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006164"],
     "releaseYear": 2022
   },

--- a/open-db/Mouse/59950cbf-ae5f-4ff4-abb5-c00f8e047d2a.json
+++ b/open-db/Mouse/59950cbf-ae5f-4ff4-abb5-c00f8e047d2a.json
@@ -2,7 +2,7 @@
   "opendb_id": "59950cbf-ae5f-4ff4-abb5-c00f8e047d2a",
   "metadata": {
     "name": "Logitech PRO 2 LIGHTSPEED Wired/Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007246", "910-007295"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/5a6f3621-9353-4362-b78a-59c8a529004c.json
+++ b/open-db/Mouse/5a6f3621-9353-4362-b78a-59c8a529004c.json
@@ -2,7 +2,7 @@
   "opendb_id": "5a6f3621-9353-4362-b78a-59c8a529004c",
   "metadata": {
     "name": "Logitech G703 Black Wireless Optical Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005091"]
   },
   "connectivity": [],

--- a/open-db/Mouse/5c47d188-964a-445d-bbb7-f9b1b8342c18.json
+++ b/open-db/Mouse/5c47d188-964a-445d-bbb7-f9b1b8342c18.json
@@ -2,7 +2,7 @@
   "opendb_id": "5c47d188-964a-445d-bbb7-f9b1b8342c18",
   "metadata": {
     "name": "Pro X Superlight 2c Wireless Gaming Mouse: 51g Compact Mini Size, Symmetrical Shape, <8 kHz Polling, 44K DPI, PowerPlay Wireless Charging Supported, USB-C, 5 Programmable Buttons, For PC/Mac - Magenta",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007529"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/63599cb4-bc07-4ae0-9aad-5dbdfd19010c.json
+++ b/open-db/Mouse/63599cb4-bc07-4ae0-9aad-5dbdfd19010c.json
@@ -2,7 +2,7 @@
   "opendb_id": "63599cb4-bc07-4ae0-9aad-5dbdfd19010c",
   "metadata": {
     "name": "Logitech G309 Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mouse Pad Bundle - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/638e0c2a-3207-4343-a9b4-fca380ae7420.json
+++ b/open-db/Mouse/638e0c2a-3207-4343-a9b4-fca380ae7420.json
@@ -2,7 +2,7 @@
   "opendb_id": "638e0c2a-3207-4343-a9b4-fca380ae7420",
   "metadata": {
     "name": "G502 Lightspeed Wireless Gaming Mouse + Powerplay Wireless Charging Mouse Pad",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/66047522-2b1c-4c6d-b8ab-f92bcada2ae2.json
+++ b/open-db/Mouse/66047522-2b1c-4c6d-b8ab-f92bcada2ae2.json
@@ -2,7 +2,7 @@
   "opendb_id": "66047522-2b1c-4c6d-b8ab-f92bcada2ae2",
   "metadata": {
     "name": "Logitech G309 LIGHTSPEED Wireless/Bluetooth Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007197", "910-007199", "910-007201"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/682fcd1a-543b-45c1-9196-bc8c6d986d25.json
+++ b/open-db/Mouse/682fcd1a-543b-45c1-9196-bc8c6d986d25.json
@@ -2,7 +2,7 @@
   "opendb_id": "682fcd1a-543b-45c1-9196-bc8c6d986d25",
   "metadata": {
     "name": "Logitech G502 X Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mouse Pad Bundle - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/6e0b3bfc-a767-47a9-ade9-761f789cef65.json
+++ b/open-db/Mouse/6e0b3bfc-a767-47a9-ade9-761f789cef65.json
@@ -2,7 +2,7 @@
   "opendb_id": "6e0b3bfc-a767-47a9-ade9-761f789cef65",
   "metadata": {
     "name": "Logitech G502 X Plus Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mouse Pad Bundle - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/7042f9f9-d4a2-4d7e-93d9-4c2c95d18b81.json
+++ b/open-db/Mouse/7042f9f9-d4a2-4d7e-93d9-4c2c95d18b81.json
@@ -2,7 +2,7 @@
   "opendb_id": "7042f9f9-d4a2-4d7e-93d9-4c2c95d18b81",
   "metadata": {
     "name": "Logitech G Pro X Superlight Wireless Optical Gaming Mouse White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005940"]
   },
   "connectivity": [],

--- a/open-db/Mouse/7117ed2f-1739-4d94-ba06-8dd2a2fcb399.json
+++ b/open-db/Mouse/7117ed2f-1739-4d94-ba06-8dd2a2fcb399.json
@@ -2,7 +2,7 @@
   "opendb_id": "7117ed2f-1739-4d94-ba06-8dd2a2fcb399",
   "metadata": {
     "name": "Logitech G502 HERO Wired Gaming Mouse + G Pro X Gaming Headset Bundle - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/7d3cc80c-52f5-422f-8e4a-8f85d6e58950.json
+++ b/open-db/Mouse/7d3cc80c-52f5-422f-8e4a-8f85d6e58950.json
@@ -2,7 +2,7 @@
   "opendb_id": "7d3cc80c-52f5-422f-8e4a-8f85d6e58950",
   "metadata": {
     "name": "Logitech G403 Prodigy Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-004797"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/7dddecdc-4308-4c79-9083-f17b36fd48fa.json
+++ b/open-db/Mouse/7dddecdc-4308-4c79-9083-f17b36fd48fa.json
@@ -2,7 +2,7 @@
   "opendb_id": "7dddecdc-4308-4c79-9083-f17b36fd48fa",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse, Black + Yeti Orb RGB Gaming Microphone with LIGHTSYNC, USB Mic for Streaming",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["G305"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/7dfb9b28-d1a4-450f-b4ca-ced688fb6215.json
+++ b/open-db/Mouse/7dfb9b28-d1a4-450f-b4ca-ced688fb6215.json
@@ -2,7 +2,7 @@
   "opendb_id": "7dfb9b28-d1a4-450f-b4ca-ced688fb6215",
   "metadata": {
     "name": "Logitech G305 LIGHTSPEED Wireless/Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006012", "910-006015"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/838bfba5-5b4e-4186-a1f8-e9479d5b3751.json
+++ b/open-db/Mouse/838bfba5-5b4e-4186-a1f8-e9479d5b3751.json
@@ -2,7 +2,7 @@
   "opendb_id": "838bfba5-5b4e-4186-a1f8-e9479d5b3751",
   "metadata": {
     "name": "Logitech G400s Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-003589", "910-003426"]
   },
   "connectivity": [],

--- a/open-db/Mouse/8706d2b8-51be-4f1b-b493-3e5033e0c17c.json
+++ b/open-db/Mouse/8706d2b8-51be-4f1b-b493-3e5033e0c17c.json
@@ -2,7 +2,7 @@
   "opendb_id": "8706d2b8-51be-4f1b-b493-3e5033e0c17c",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse, Lilac + Yeti Orb RGB Gaming Microphone with LIGHTSYNC, USB Mic for Streaming",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["G305"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/8c19f254-f584-4dfa-8ac1-dcee71f8ca9a.json
+++ b/open-db/Mouse/8c19f254-f584-4dfa-8ac1-dcee71f8ca9a.json
@@ -2,7 +2,7 @@
   "opendb_id": "8c19f254-f584-4dfa-8ac1-dcee71f8ca9a",
   "metadata": {
     "name": "Logitech G203 Lightsync Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005791"]
   },
   "connectivity": [],

--- a/open-db/Mouse/8ef80e26-90fe-4380-876c-72e9144c87eb.json
+++ b/open-db/Mouse/8ef80e26-90fe-4380-876c-72e9144c87eb.json
@@ -2,7 +2,7 @@
   "opendb_id": "8ef80e26-90fe-4380-876c-72e9144c87eb",
   "metadata": {
     "name": "Logitech G502 X Plus Wired and Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006160"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/937954d3-543a-4183-88d8-1728ce4e2ab0.json
+++ b/open-db/Mouse/937954d3-543a-4183-88d8-1728ce4e2ab0.json
@@ -2,7 +2,7 @@
   "opendb_id": "937954d3-543a-4183-88d8-1728ce4e2ab0",
   "metadata": {
     "name": "Logitech G502 SE HERO Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005728"]
   },
   "connectivity": [],

--- a/open-db/Mouse/954e0fec-be7f-4047-8e72-84a520e39755.json
+++ b/open-db/Mouse/954e0fec-be7f-4047-8e72-84a520e39755.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["941-000119"],
     "name": "Logitech G Gaming Driving Force Shifter - Compatible with G29 and G920 Driving Force Racing Wheels for Playstation 4, Xbox One, and PC",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "lighting": [],

--- a/open-db/Mouse/96788f08-e4bf-478d-8ab9-1be478bb5ccd.json
+++ b/open-db/Mouse/96788f08-e4bf-478d-8ab9-1be478bb5ccd.json
@@ -2,7 +2,7 @@
   "opendb_id": "96788f08-e4bf-478d-8ab9-1be478bb5ccd",
   "metadata": {
     "name": "Logitech G502 X Wireless Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006187"]
   },
   "connectivity": [],

--- a/open-db/Mouse/997f9d9d-2f50-4b63-be67-24ffe90548fd.json
+++ b/open-db/Mouse/997f9d9d-2f50-4b63-be67-24ffe90548fd.json
@@ -2,7 +2,7 @@
   "opendb_id": "997f9d9d-2f50-4b63-be67-24ffe90548fd",
   "metadata": {
     "name": "Logitech G903 HERO Optical Wireless Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005670"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/a3946af7-7e8f-4b19-8e5e-80ee4f1c9c57.json
+++ b/open-db/Mouse/a3946af7-7e8f-4b19-8e5e-80ee4f1c9c57.json
@@ -2,7 +2,7 @@
   "opendb_id": "a3946af7-7e8f-4b19-8e5e-80ee4f1c9c57",
   "metadata": {
     "name": "Logitech G604 LIGHTSPEED Wireless Optical Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005622"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/a4e70fcc-07df-443f-a343-8942c8418be7.json
+++ b/open-db/Mouse/a4e70fcc-07df-443f-a343-8942c8418be7.json
@@ -2,7 +2,7 @@
   "opendb_id": "a4e70fcc-07df-443f-a343-8942c8418be7",
   "metadata": {
     "name": "Logitech G502 X Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006144"]
   },
   "connectivity": [],

--- a/open-db/Mouse/a6b5fc1b-086c-4d93-93fd-464a3773488e.json
+++ b/open-db/Mouse/a6b5fc1b-086c-4d93-93fd-464a3773488e.json
@@ -2,7 +2,7 @@
   "opendb_id": "a6b5fc1b-086c-4d93-93fd-464a3773488e",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse + G515 TKL Wireless Gaming Keyboard (Tactile) Bundle: White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz", "Wired"],

--- a/open-db/Mouse/ac9d0639-95cf-42dd-807b-deee1b535cd4.json
+++ b/open-db/Mouse/ac9d0639-95cf-42dd-807b-deee1b535cd4.json
@@ -2,7 +2,7 @@
   "opendb_id": "ac9d0639-95cf-42dd-807b-deee1b535cd4",
   "metadata": {
     "name": "Logitech G502 X Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006136"]
   },
   "connectivity": [],

--- a/open-db/Mouse/acc55bbd-2ea8-4ef5-918a-12c7acd9867d.json
+++ b/open-db/Mouse/acc55bbd-2ea8-4ef5-918a-12c7acd9867d.json
@@ -2,7 +2,7 @@
   "opendb_id": "acc55bbd-2ea8-4ef5-918a-12c7acd9867d",
   "metadata": {
     "name": "Logitech Pro X Superlight 2 Dex Wired/Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007328", "910-007357"]
   },
   "connectivity": [],

--- a/open-db/Mouse/acca3650-f691-4029-bec2-38a7c7ed4044.json
+++ b/open-db/Mouse/acca3650-f691-4029-bec2-38a7c7ed4044.json
@@ -2,7 +2,7 @@
   "opendb_id": "acca3650-f691-4029-bec2-38a7c7ed4044",
   "metadata": {
     "name": "Logitech G203 Wired Gaming Mouse + G213 Prodigy Gaming Keyboard Bundle - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/af797dca-6b40-43fa-a8f3-5a1a2a8b838a.json
+++ b/open-db/Mouse/af797dca-6b40-43fa-a8f3-5a1a2a8b838a.json
@@ -2,7 +2,7 @@
   "opendb_id": "af797dca-6b40-43fa-a8f3-5a1a2a8b838a",
   "metadata": {
     "name": "Logitech G PRO X Superlight 2 SE Wireless Gaming Mouse, 60 g pro-Grade Mouse with 5 programmable Buttons, 44K DPI Sensor, 888+ IPS, 1 kHz Report Rate, USB-C Charging for PC/Mac - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007655"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/afc696a7-76c1-4009-9435-b0f050a738d5.json
+++ b/open-db/Mouse/afc696a7-76c1-4009-9435-b0f050a738d5.json
@@ -2,7 +2,7 @@
   "opendb_id": "afc696a7-76c1-4009-9435-b0f050a738d5",
   "metadata": {
     "name": "Logitech G502 X Wired Gaming Mouse + G515 TKL Wireless Gaming Keyboard (Tactile) Bundle: White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/b0351ff5-3be7-4fdb-bf74-460bf08be4af.json
+++ b/open-db/Mouse/b0351ff5-3be7-4fdb-bf74-460bf08be4af.json
@@ -2,7 +2,7 @@
   "opendb_id": "b0351ff5-3be7-4fdb-bf74-460bf08be4af",
   "metadata": {
     "name": "Logitech G Pro League of Legends Wireless/Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006449", "910-006451", "910-006450"]
   },
   "connectivity": [],

--- a/open-db/Mouse/b0851343-02db-4ffe-a6b4-86071d4093b6.json
+++ b/open-db/Mouse/b0851343-02db-4ffe-a6b4-86071d4093b6.json
@@ -2,7 +2,7 @@
   "opendb_id": "b0851343-02db-4ffe-a6b4-86071d4093b6",
   "metadata": {
     "name": "G703 Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mousepad Bundle - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/b49705b2-f0b4-431d-b42e-2fa53958106c.json
+++ b/open-db/Mouse/b49705b2-f0b4-431d-b42e-2fa53958106c.json
@@ -2,7 +2,7 @@
   "opendb_id": "b49705b2-f0b4-431d-b42e-2fa53958106c",
   "metadata": {
     "name": "Logitech G502 X Wired Gaming Mouse + G335 Wired Gaming Headset - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/b6c3f1bf-7aaf-4012-b6a7-d62276751568.json
+++ b/open-db/Mouse/b6c3f1bf-7aaf-4012-b6a7-d62276751568.json
@@ -2,7 +2,7 @@
   "opendb_id": "b6c3f1bf-7aaf-4012-b6a7-d62276751568",
   "metadata": {
     "name": "Logitech G Pro Wireless 2 Gaming Mouse + Powerplay 2 Wireless Chargining Mouse Pad Bundle - Magenta",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/b727b264-7909-4487-9cfb-cab0458816f3.json
+++ b/open-db/Mouse/b727b264-7909-4487-9cfb-cab0458816f3.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["910-005469"],
     "name": "Logitech G502 HERO High Performance Gaming Mouse",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "lighting": [],

--- a/open-db/Mouse/b850db3a-4728-4d41-8bc6-f295fe8b8133.json
+++ b/open-db/Mouse/b850db3a-4728-4d41-8bc6-f295fe8b8133.json
@@ -2,7 +2,7 @@
   "opendb_id": "b850db3a-4728-4d41-8bc6-f295fe8b8133",
   "metadata": {
     "name": "Logitech G500 Laser Wired Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-001259"]
   },
   "connectivity": [],

--- a/open-db/Mouse/bb5395de-4b4a-4f09-a040-2d5858390f1f.json
+++ b/open-db/Mouse/bb5395de-4b4a-4f09-a040-2d5858390f1f.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["910-005565"],
     "name": "Logitech G502 Lightspeed Wireless Gaming Mouse with Hero 16K Sensor, PowerPlay Compatible, Tunable Weights and Lightsync RGB",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "lighting": [],

--- a/open-db/Mouse/bbf688a7-8807-46be-9bd3-9a9ae539ae1a.json
+++ b/open-db/Mouse/bbf688a7-8807-46be-9bd3-9a9ae539ae1a.json
@@ -2,7 +2,7 @@
   "opendb_id": "bbf688a7-8807-46be-9bd3-9a9ae539ae1a",
   "metadata": {
     "name": "Logitech G502 X Plus Wireless RGB Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006160"],
     "releaseYear": 2022
   },

--- a/open-db/Mouse/bdc5ac3c-9bf8-45f6-b2d8-ca05243fd5db.json
+++ b/open-db/Mouse/bdc5ac3c-9bf8-45f6-b2d8-ca05243fd5db.json
@@ -2,7 +2,7 @@
   "opendb_id": "bdc5ac3c-9bf8-45f6-b2d8-ca05243fd5db",
   "metadata": {
     "name": "Logitech G305 LIGHTSPEED Wireless Optical White Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005289"],
     "series": "LIGHTSPEED",
     "variant": "G305 White",

--- a/open-db/Mouse/bec2ec2a-0fbb-4ee0-823a-5ec38b97c000.json
+++ b/open-db/Mouse/bec2ec2a-0fbb-4ee0-823a-5ec38b97c000.json
@@ -2,7 +2,7 @@
   "opendb_id": "bec2ec2a-0fbb-4ee0-823a-5ec38b97c000",
   "metadata": {
     "name": "Logitech G502 X Lightspeed Wireless Gaming Mouse + G733 Lightspeed Wireless Gaming Headset - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/c5613b79-42fe-48bd-af93-31f7bf80a13c.json
+++ b/open-db/Mouse/c5613b79-42fe-48bd-af93-31f7bf80a13c.json
@@ -2,7 +2,7 @@
   "opendb_id": "c5613b79-42fe-48bd-af93-31f7bf80a13c",
   "metadata": {
     "name": "Logitech PRO 2 LIGHTSPEED Wired/Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007291", "910-007309"]
   },
   "connectivity": [],

--- a/open-db/Mouse/c58492fe-a3cd-4a85-96dc-00c069b3b286.json
+++ b/open-db/Mouse/c58492fe-a3cd-4a85-96dc-00c069b3b286.json
@@ -2,7 +2,7 @@
   "opendb_id": "c58492fe-a3cd-4a85-96dc-00c069b3b286",
   "metadata": {
     "name": "Logitech G Pro X Superlight Wireless Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005878", "910-005882"],
     "series": "G PRO X",
     "variant": "Superlight",

--- a/open-db/Mouse/c88554f2-681b-4fb9-90cb-65f9b73d8b2e.json
+++ b/open-db/Mouse/c88554f2-681b-4fb9-90cb-65f9b73d8b2e.json
@@ -2,7 +2,7 @@
   "opendb_id": "c88554f2-681b-4fb9-90cb-65f9b73d8b2e",
   "metadata": {
     "name": "Logitech G309 Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mouse Pad Bundle - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/cca9151c-09ca-49f2-ac05-a82d11349707.json
+++ b/open-db/Mouse/cca9151c-09ca-49f2-ac05-a82d11349707.json
@@ -2,7 +2,7 @@
   "opendb_id": "cca9151c-09ca-49f2-ac05-a82d11349707",
   "metadata": {
     "name": "Logitech G PRO X Superlight 2 SE Wireless Gaming Mouse, 60 g pro-Grade Mouse with 5 programmable Buttons, 44K DPI Sensor, 888+ IPS, 1 kHz Report Rate, USB-C Charging for PC/Mac - Red",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007651"]
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-C"],

--- a/open-db/Mouse/d3364849-3f3a-41c6-b86e-e0f7528cf7bc.json
+++ b/open-db/Mouse/d3364849-3f3a-41c6-b86e-e0f7528cf7bc.json
@@ -2,7 +2,7 @@
   "opendb_id": "d3364849-3f3a-41c6-b86e-e0f7528cf7bc",
   "metadata": {
     "name": "Logitech G Pro Shroud Wireless/Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005974", "910-005975"]
   },
   "connectivity": [],

--- a/open-db/Mouse/d34829fa-fd55-4cd1-bfd0-785a213c3eec.json
+++ b/open-db/Mouse/d34829fa-fd55-4cd1-bfd0-785a213c3eec.json
@@ -2,7 +2,7 @@
   "opendb_id": "d34829fa-fd55-4cd1-bfd0-785a213c3eec",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse + G733 Lightspeed Wireless Gaming Headset Bundle - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["G733"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/d9f8e69e-ddfe-44eb-bf65-0c76063458a9.json
+++ b/open-db/Mouse/d9f8e69e-ddfe-44eb-bf65-0c76063458a9.json
@@ -2,7 +2,7 @@
   "opendb_id": "d9f8e69e-ddfe-44eb-bf65-0c76063458a9",
   "metadata": {
     "name": "Logitech G309 Lightspeed Wireless Gaming Mouse, Lightweight, LIGHTFORCE Hybrid Switches, Hero 25K Sensor, 300+ Hour Battery Life, 6 Programmable Buttons, PC & Mac - Genshin Impact Limited Edition",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007481"]
   },
   "connectivity": ["Bluetooth", "Wireless 2.4GHz"],

--- a/open-db/Mouse/dc3c3df4-66c0-403b-b473-417f832d2f80.json
+++ b/open-db/Mouse/dc3c3df4-66c0-403b-b473-417f832d2f80.json
@@ -2,7 +2,7 @@
   "opendb_id": "dc3c3df4-66c0-403b-b473-417f832d2f80",
   "metadata": {
     "name": "Logitech G502 X Plus Lightspeed Wireless Gaming Mouse + Powerplay 2 Wireless Charging Mouse Pad Bundle - White",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz", "Wired USB-A"],

--- a/open-db/Mouse/dc798f40-5d23-40aa-aff0-5932d0bf2431.json
+++ b/open-db/Mouse/dc798f40-5d23-40aa-aff0-5932d0bf2431.json
@@ -2,7 +2,7 @@
   "opendb_id": "dc798f40-5d23-40aa-aff0-5932d0bf2431",
   "metadata": {
     "name": "Logitech G305 Lightspeed Wireless Gaming Mouse + G733 Lightspeed Wireless Gaming Headset Bundle - Blue",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["G305"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/ded2cd42-4621-44d7-8b77-5421f12a786e.json
+++ b/open-db/Mouse/ded2cd42-4621-44d7-8b77-5421f12a786e.json
@@ -2,7 +2,7 @@
   "opendb_id": "ded2cd42-4621-44d7-8b77-5421f12a786e",
   "metadata": {
     "name": "Logitech G500s Laser Wired Laser Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-003602"]
   },
   "connectivity": [],

--- a/open-db/Mouse/e01300fe-c97b-480c-b432-95ceab2cd5c8.json
+++ b/open-db/Mouse/e01300fe-c97b-480c-b432-95ceab2cd5c8.json
@@ -2,7 +2,7 @@
   "opendb_id": "e01300fe-c97b-480c-b432-95ceab2cd5c8",
   "metadata": {
     "name": "Logitech PRO X SUPERLIGHT 2 DEX Wired/Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-007363", "910-007365"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/e32b16cd-e183-4ad4-b9a7-dbdba5bf6e48.json
+++ b/open-db/Mouse/e32b16cd-e183-4ad4-b9a7-dbdba5bf6e48.json
@@ -2,7 +2,7 @@
   "opendb_id": "e32b16cd-e183-4ad4-b9a7-dbdba5bf6e48",
   "metadata": {
     "name": "Logitech G203 Lightsync Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-005792", "910-005791"]
   },
   "connectivity": [],

--- a/open-db/Mouse/e86d9712-c441-4625-b818-2bd2b122daa2.json
+++ b/open-db/Mouse/e86d9712-c441-4625-b818-2bd2b122daa2.json
@@ -2,7 +2,7 @@
   "opendb_id": "e86d9712-c441-4625-b818-2bd2b122daa2",
   "metadata": {
     "name": "Logitech G303 SHROUD EDITION Wireless Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006103"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/ea1e706c-64a9-486f-a39d-dd303b4ca5fd.json
+++ b/open-db/Mouse/ea1e706c-64a9-486f-a39d-dd303b4ca5fd.json
@@ -2,7 +2,7 @@
   "opendb_id": "ea1e706c-64a9-486f-a39d-dd303b4ca5fd",
   "metadata": {
     "name": "Logitech G302 Daedalus Prime Moba Wired Optical Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-004205", "G302"]
   },
   "connectivity": ["Wired"],

--- a/open-db/Mouse/ec80ee75-8e28-432f-a5e8-c9d979c10073.json
+++ b/open-db/Mouse/ec80ee75-8e28-432f-a5e8-c9d979c10073.json
@@ -2,7 +2,7 @@
   "opendb_id": "ec80ee75-8e28-432f-a5e8-c9d979c10073",
   "metadata": {
     "name": "Logitech G502 X Lightspeed Wireless Gaming Mouse + G733 Lightspeed Wireless Gaming Headset - Black",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": []
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Mouse/f8327b79-6d9a-4f12-bf10-10eb69298825.json
+++ b/open-db/Mouse/f8327b79-6d9a-4f12-bf10-10eb69298825.json
@@ -2,7 +2,7 @@
   "opendb_id": "f8327b79-6d9a-4f12-bf10-10eb69298825",
   "metadata": {
     "name": "Logitech G100s Wired Optical Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-003533"]
   },
   "connectivity": [],

--- a/open-db/Mouse/fa669367-ca32-4124-9cc7-bda0fc00f2f3.json
+++ b/open-db/Mouse/fa669367-ca32-4124-9cc7-bda0fc00f2f3.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["910-005729"],
     "name": "Logitech G502 Hero High Performance Gaming Mouse Special Edition, Hero 16K Sensor, 16 000 DPI, RGB, Adjustable Weights, 11 Programmable Buttons, On-Board Memory, PC/Mac - Black/White",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity": [],
   "lighting": [],

--- a/open-db/Mouse/fb841758-7d50-4ae1-a4a0-a4cd9a5f7f0c.json
+++ b/open-db/Mouse/fb841758-7d50-4ae1-a4a0-a4cd9a5f7f0c.json
@@ -2,7 +2,7 @@
   "opendb_id": "fb841758-7d50-4ae1-a4a0-a4cd9a5f7f0c",
   "metadata": {
     "name": "Logitech PRO X Superlight 2 Wireless/Wired Optical White Gaming Mouse",
-    "manufacturer": "Logitech G",
+    "manufacturer": "Logitech",
     "part_numbers": ["910-006636", "910-006640", "910-006639"]
   },
   "connectivity": ["Wireless 2.4GHz"],

--- a/open-db/Speaker/026eaf1b-5db6-46ba-ad3b-5c2eeaca983b.json
+++ b/open-db/Speaker/026eaf1b-5db6-46ba-ad3b-5c2eeaca983b.json
@@ -2,7 +2,7 @@
   "opendb_id": "026eaf1b-5db6-46ba-ad3b-5c2eeaca983b",
   "metadata": {
     "name": "Ultimate Ears WONDERBOOM 4 Ultraportable Bluetooth Speaker",
-    "manufacturer": "Ultimate Ears / Logitech",
+    "manufacturer": "Ultimate Ears",
     "part_numbers": ["494bc6290bfbf93a", "984-001877"],
     "releaseYear": 2024
   },

--- a/open-db/Speaker/2caaae7c-f25b-4af4-8227-31edf93ff1a9.json
+++ b/open-db/Speaker/2caaae7c-f25b-4af4-8227-31edf93ff1a9.json
@@ -2,7 +2,7 @@
   "opendb_id": "2caaae7c-f25b-4af4-8227-31edf93ff1a9",
   "metadata": {
     "name": "Ultimate Ears MEGABOOM 4 Bluetooth Speaker",
-    "manufacturer": "Ultimate Ears / Logitech",
+    "manufacturer": "Ultimate Ears",
     "part_numbers": ["984-001997", "984-001994"],
     "releaseYear": 2024
   },

--- a/open-db/Speaker/35d6e0b8-5b9d-4d93-942a-5750f5df9699.json
+++ b/open-db/Speaker/35d6e0b8-5b9d-4d93-942a-5750f5df9699.json
@@ -2,7 +2,7 @@
   "opendb_id": "35d6e0b8-5b9d-4d93-942a-5750f5df9699",
   "metadata": {
     "name": "Ultimate Ears BOOM 4 Bluetooth Speaker",
-    "manufacturer": "Logitech / Ultimate Ears",
+    "manufacturer": "Ultimate Ears",
     "part_numbers": ["c0a5d3f90999ea9a"]
   },
   "lighting": [],

--- a/open-db/Speaker/b6360158-1eec-4643-bf6d-dba2730d9a08.json
+++ b/open-db/Speaker/b6360158-1eec-4643-bf6d-dba2730d9a08.json
@@ -2,7 +2,7 @@
   "opendb_id": "b6360158-1eec-4643-bf6d-dba2730d9a08",
   "metadata": {
     "name": "Ultimate Ears EVERBOOM Portable Bluetooth Speaker",
-    "manufacturer": "Logitech / Ultimate Ears",
+    "manufacturer": "Ultimate Ears",
     "part_numbers": ["EVERBOOM", "de89595d885c3a05"]
   },
   "lighting": [],

--- a/open-db/Speaker/ece03ac7-7d6c-442a-a5d8-acde3bd1a1f3.json
+++ b/open-db/Speaker/ece03ac7-7d6c-442a-a5d8-acde3bd1a1f3.json
@@ -2,7 +2,7 @@
   "opendb_id": "ece03ac7-7d6c-442a-a5d8-acde3bd1a1f3",
   "metadata": {
     "name": "Ultimate Ears BOOM 4 Bluetooth Speaker",
-    "manufacturer": "Ultimate Ears / Logitech",
+    "manufacturer": "Ultimate Ears",
     "part_numbers": ["aed79229ba557d8e"]
   },
   "lighting": [],

--- a/open-db/Speaker/ef63fde0-217b-47c7-a2cc-c7ff46414995.json
+++ b/open-db/Speaker/ef63fde0-217b-47c7-a2cc-c7ff46414995.json
@@ -2,7 +2,7 @@
   "opendb_id": "ef63fde0-217b-47c7-a2cc-c7ff46414995",
   "metadata": {
     "name": "Ultimate Ears MEGABOOM 4 Bluetooth Speaker",
-    "manufacturer": "Logitech / Ultimate Ears",
+    "manufacturer": "Ultimate Ears",
     "part_numbers": ["adb393f5f2596e4a", "984-001964"]
   },
   "lighting": [],

--- a/open-db/Speaker/f5186b56-25b2-410d-88c8-da06f068f1f3.json
+++ b/open-db/Speaker/f5186b56-25b2-410d-88c8-da06f068f1f3.json
@@ -2,7 +2,7 @@
   "opendb_id": "f5186b56-25b2-410d-88c8-da06f068f1f3",
   "metadata": {
     "name": "Ultimate Ears WONDERBOOM 4 Portable Bluetooth Speaker Joyous Bright",
-    "manufacturer": "Logitech / Ultimate Ears",
+    "manufacturer": "Ultimate Ears",
     "part_numbers": ["b7bc18d7f8548343", "984-001876"],
     "releaseYear": 2024
   },

--- a/open-db/Webcam/1c8f95d8-9850-42b0-9266-f70d1e1c54a4.json
+++ b/open-db/Webcam/1c8f95d8-9850-42b0-9266-f70d1e1c54a4.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["960-001297", "Logitechstreamcam"],
     "name": "Logitech StreamCam Webcam",
-    "manufacturer": "Logitech for Creators"
+    "manufacturer": "Logitech"
   },
   "connectivity_type": [],
   "lighting": [],

--- a/open-db/Webcam/48d16a91-1d20-4160-9aa3-c4e2fb20d04b.json
+++ b/open-db/Webcam/48d16a91-1d20-4160-9aa3-c4e2fb20d04b.json
@@ -2,7 +2,7 @@
   "opendb_id": "48d16a91-1d20-4160-9aa3-c4e2fb20d04b",
   "metadata": {
     "name": "Logitech BRIO Ultra HD Pro 4K Webcam",
-    "manufacturer": "Calibra",
+    "manufacturer": "Logitech",
     "part_numbers": ["960-001105", "197644222865"],
     "releaseYear": 2017
   },

--- a/open-db/Webcam/7d822b6d-7a74-4e01-8dc4-3dbf5dcf9679.json
+++ b/open-db/Webcam/7d822b6d-7a74-4e01-8dc4-3dbf5dcf9679.json
@@ -2,7 +2,7 @@
   "opendb_id": "7d822b6d-7a74-4e01-8dc4-3dbf5dcf9679",
   "metadata": {
     "name": "Logitech StreamCam 1080p 720p Webcam",
-    "manufacturer": "Logitech for Creators",
+    "manufacturer": "Logitech",
     "part_numbers": ["960-001289"]
   },
   "connectivity_type": [],

--- a/open-db/Webcam/8757b57f-316a-4e3a-b22d-dc7a400076ce.json
+++ b/open-db/Webcam/8757b57f-316a-4e3a-b22d-dc7a400076ce.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["Logitech StreamCam Plus", "960-001280"],
     "name": "Logitech StreamCam Plus Webcam",
-    "manufacturer": "Logitech G"
+    "manufacturer": "Logitech"
   },
   "connectivity_type": [],
   "lighting": [],

--- a/open-db/Webcam/a2cb666a-f5d8-4226-a51d-25c30844f156.json
+++ b/open-db/Webcam/a2cb666a-f5d8-4226-a51d-25c30844f156.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["960-001087"],
     "name": "Logitech C922 Pro Stream HD Webcam",
-    "manufacturer": "V-TAC",
+    "manufacturer": "Logitech",
     "releaseYear": 2016
   },
   "connectivity_type": ["Wired", "Wired USB-A", "Wired USB-C"],

--- a/open-db/Webcam/c76f9d5b-ef0c-4911-a490-f37fc1b49a9e.json
+++ b/open-db/Webcam/c76f9d5b-ef0c-4911-a490-f37fc1b49a9e.json
@@ -3,7 +3,7 @@
   "metadata": {
     "part_numbers": ["960-001286"],
     "name": "Logitech StreamCam Webcam",
-    "manufacturer": "Logitech for Creators"
+    "manufacturer": "Logitech"
   },
   "connectivity_type": [],
   "lighting": [],


### PR DESCRIPTION
## Summary

- Normalize 199 `Logitech G` manufacturer values to the company name `Logitech`.
- Normalize 4 `Logitech for Creators` manufacturer values to `Logitech`.
- Normalize 7 compound `Logitech / Ultimate Ears` and `Ultimate Ears / Logitech` values to `Ultimate Ears`.
- Correct 7 clearly wrong or missing manufacturer values on named Logitech products.

This is a setup-catalog-only data correction across 217 JSON records. OpenDB's variant guidance defines `metadata.manufacturer` as the company name and reserves `series` for product lines/families, so `Logitech G` and `Logitech for Creators` are not separate manufacturer values.

## Corrected assignments

- Logitech MK295: `YEYIAN` -> `Logitech`
- Logitech K120: `Pantheon` -> `Logitech`
- Logitech V470: `Jaybird` -> `Logitech`
- Logitech G935: missing -> `Logitech` (2 records)
- Logitech BRIO: `Calibra` -> `Logitech`
- Logitech C922: `V-TAC` -> `Logitech`

## Scope

- No schema, application code, IDs, product names, part numbers, specifications, or retailer fields changed.
- Other manufacturer casing/punctuation groups are excluded pending vendor-by-vendor canonicalization.
- Potential duplicate products and unrelated part-number anomalies are excluded from this PR.
- Feature diagram: not applicable; this is a data-only normalization.

## Validation

- Dry-run normalization guard found exactly 217 intended records before applying changes.
- `./scripts/validate.sh`: 217 passed / 217 total.
- Post-change setup-catalog audit: zero remaining targeted aliases, zero named Logitech manufacturer mismatches, and zero named Logitech records missing a manufacturer.
- `git diff --check`: passed.
- Diff audit: 217 files, 219 insertions, 217 deletions; changes are limited to manufacturer values and the two required trailing commas where a previously missing manufacturer was added.

## Sources

- OpenDB `docs/VARIANTS.md` and category JSON schemas/data.
- Official Logitech product pages for K120, MK295, V470, BRIO, C922, and G935.
- Official Logitech corporate press release describing Logitech G as a brand of Logitech.
- Official Ultimate Ears storefront.
- Read-only BuildCores setup-catalog audit used to identify the normalization targets; this PR does not write to production.

## AI-assisted development disclosure

- Model(s): OpenAI GPT-5 (Codex)
- Agent harness(es): Codex desktop
- Initial user prompt or faithful summary: Audit duplicate setup-category brands such as Logitech, Logitech G, and Logitech for Creators, then create an OpenDB PR for the cleanup.
- Material sources consulted: OpenDB repository guidance, schemas, and catalog data; official Logitech and Ultimate Ears product/corporate pages; read-only BuildCores setup-catalog audit.
