### PR TITLE
Add Gravastar mercury K1 - Opaline White

### DIFF
--- a/open-db/Keyboard/dc493641-8062-45e5-aa11-a159ac63babc.json
+++ b/open-db/Keyboard/dc493641-8062-45e5-aa11-a159ac63babc.json
@@ -1,0 +1,33 @@
+{
+  "opendb_id": "dc493641-8062-45e5-aa11-a159ac63babc",
+  "metadata": {
+    "name": "Mercury K1 - Opaline White",
+    "manufacturer": "GravaStar",
+    "series": "Mercury K1",
+    "variant": "Opaline White"
+  },
+  "switch": "GravaStar Custom Linear Switches",
+  "switch_type": "Linear",
+  "size": "75%",
+  "hot_swappable": true,
+  "backlighting": "RGB",
+  "lighting": [
+    "RGB"
+  ],
+  "features": [
+    "Knob"
+  ],
+  "connectivity": [
+    "Bluetooth",
+    "Wireless 2.4GHz",
+    "Wired USB-C"
+  ],
+  "keycap_material": "PBT and PC",
+  "frame_material": "Aluminum Alloy",
+  "polling_rate": 1000,
+  "battery_capacity": 8000,
+  "general_product_information": {
+    "amazon_sku": "B0GTY7H2S3",
+    "manufacturer_url": "https://gravastar.com/products/mercury-k1-special-edition-opaline-white"
+  }
+}


### PR DESCRIPTION
Hello BuildCores team,
I’d like to politely ask if you could add the GravaStar Mercury K1 - Opaline White to the website.

I added the missing OpenDB entry using information from the official GravaStar product page:
https://gravastar.com/products/mercury-k1-special-edition-opaline-white

Thank you :)