### PR TITLE
Add complete Gigatech Gaming prebuilt catalog

### DIFF
--- a/open-db/PrebuiltDesktop/011332ca-44ab-46c8-aace-6bea629d08fd.json
+++ b/open-db/PrebuiltDesktop/011332ca-44ab-46c8-aace-6bea629d08fd.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "011332ca-44ab-46c8-aace-6bea629d08fd",
+  "metadata": {
+    "name": "Nova 3 Bundle - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3L2-26"
+    ],
+    "series": "Nova 3 Bundle",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3-bundle?variant=51950790934829"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568945",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3L2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790934829",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/011332ca-44ab-46c8-aace-6bea629d08fd.json
+++ b/open-db/PrebuiltDesktop/011332ca-44ab-46c8-aace-6bea629d08fd.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 Bundle - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3L2-26"
-    ],
+    "part_numbers": ["Nova-3L2-26"],
     "series": "Nova 3 Bundle",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/0364840b-751b-4710-9cd8-abbb2433f379.json
+++ b/open-db/PrebuiltDesktop/0364840b-751b-4710-9cd8-abbb2433f379.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 Bundle - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3I2-26"
-    ],
+    "part_numbers": ["Nova-3I2-26"],
     "series": "Nova 3 Bundle",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/0364840b-751b-4710-9cd8-abbb2433f379.json
+++ b/open-db/PrebuiltDesktop/0364840b-751b-4710-9cd8-abbb2433f379.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "0364840b-751b-4710-9cd8-abbb2433f379",
+  "metadata": {
+    "name": "Nova 3 Bundle - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3I2-26"
+    ],
+    "series": "Nova 3 Bundle",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3-bundle?variant=51950790836525"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568914",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3I2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790836525",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/075bc5f5-69e7-4f75-ae25-81659fbc6ade.json
+++ b/open-db/PrebuiltDesktop/075bc5f5-69e7-4f75-ae25-81659fbc6ade.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "075bc5f5-69e7-4f75-ae25-81659fbc6ade",
+  "metadata": {
+    "name": "Apollo 5 Bundle - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5L2-25"
+    ],
+    "series": "Apollo 5 Bundle",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5-bundle?variant=51950792769837"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133762",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792769837",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/075bc5f5-69e7-4f75-ae25-81659fbc6ade.json
+++ b/open-db/PrebuiltDesktop/075bc5f5-69e7-4f75-ae25-81659fbc6ade.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 Bundle - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5L2-25"
-    ],
+    "part_numbers": ["Apollo-5L2-25"],
     "series": "Apollo 5 Bundle",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/082c92bd-bf96-4d66-8a89-3a690fcd23f7.json
+++ b/open-db/PrebuiltDesktop/082c92bd-bf96-4d66-8a89-3a690fcd23f7.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 Bundle - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7J2-26"
-    ],
+    "part_numbers": ["Nova-7J2-26"],
     "series": "Nova 7 Bundle",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/082c92bd-bf96-4d66-8a89-3a690fcd23f7.json
+++ b/open-db/PrebuiltDesktop/082c92bd-bf96-4d66-8a89-3a690fcd23f7.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "082c92bd-bf96-4d66-8a89-3a690fcd23f7",
+  "metadata": {
+    "name": "Nova 7 Bundle - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7J2-26"
+    ],
+    "series": "Nova 7 Bundle",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7-bundle?variant=51950790607149"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569126",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7J2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790607149",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/085a50e0-9894-459c-bd4f-d683828f9d07.json
+++ b/open-db/PrebuiltDesktop/085a50e0-9894-459c-bd4f-d683828f9d07.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5K-25"
-    ],
+    "part_numbers": ["Titan-5K-25"],
     "series": "Titan 5",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/085a50e0-9894-459c-bd4f-d683828f9d07.json
+++ b/open-db/PrebuiltDesktop/085a50e0-9894-459c-bd4f-d683828f9d07.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "085a50e0-9894-459c-bd4f-d683828f9d07",
+  "metadata": {
+    "name": "Titan 5 - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5K-25"
+    ],
+    "series": "Titan 5",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5?variant=51950793490733"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131850",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793490733",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/0b42df24-eecb-4a4a-b951-a8bd23c4427e.json
+++ b/open-db/PrebuiltDesktop/0b42df24-eecb-4a4a-b951-a8bd23c4427e.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 Bundle - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7K2-25"
-    ],
+    "part_numbers": ["Titan-7K2-25"],
     "series": "Titan 7 Bundle",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/0b42df24-eecb-4a4a-b951-a8bd23c4427e.json
+++ b/open-db/PrebuiltDesktop/0b42df24-eecb-4a4a-b951-a8bd23c4427e.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "0b42df24-eecb-4a4a-b951-a8bd23c4427e",
+  "metadata": {
+    "name": "Titan 7 Bundle - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7K2-25"
+    ],
+    "series": "Titan 7 Bundle",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7-bundle?variant=51950791983405"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134158",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791983405",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/11a7138b-7f67-43e8-866c-6b795eb0d148.json
+++ b/open-db/PrebuiltDesktop/11a7138b-7f67-43e8-866c-6b795eb0d148.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5K-26"
-    ],
+    "part_numbers": ["Nova-5K-26"],
     "series": "Nova 5",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/11a7138b-7f67-43e8-866c-6b795eb0d148.json
+++ b/open-db/PrebuiltDesktop/11a7138b-7f67-43e8-866c-6b795eb0d148.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "11a7138b-7f67-43e8-866c-6b795eb0d148",
+  "metadata": {
+    "name": "Nova 5 - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5K-26"
+    ],
+    "series": "Nova 5",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5?variant=51950791229741"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568730",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5K-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791229741",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/1258318b-5d91-426a-9494-207352c7e32c.json
+++ b/open-db/PrebuiltDesktop/1258318b-5d91-426a-9494-207352c7e32c.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "1258318b-5d91-426a-9494-207352c7e32c",
+  "metadata": {
+    "name": "Omega 5 - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5K-25"
+    ],
+    "series": "Omega 5",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5?variant=51950793064749"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132154",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793064749",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/1258318b-5d91-426a-9494-207352c7e32c.json
+++ b/open-db/PrebuiltDesktop/1258318b-5d91-426a-9494-207352c7e32c.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5K-25"
-    ],
+    "part_numbers": ["Omega-5K-25"],
     "series": "Omega 5",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/13877bc0-a5a2-4ef9-9903-2400077b8fa6.json
+++ b/open-db/PrebuiltDesktop/13877bc0-a5a2-4ef9-9903-2400077b8fa6.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "13877bc0-a5a2-4ef9-9903-2400077b8fa6",
+  "metadata": {
+    "name": "Omega 3 - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3J-25"
+    ],
+    "series": "Omega 3",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3?variant=51950793163053"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132048",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793163053",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/13877bc0-a5a2-4ef9-9903-2400077b8fa6.json
+++ b/open-db/PrebuiltDesktop/13877bc0-a5a2-4ef9-9903-2400077b8fa6.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3J-25"
-    ],
+    "part_numbers": ["Omega-3J-25"],
     "series": "Omega 3",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/143febb8-12dc-4bf7-9607-efc0983ec160.json
+++ b/open-db/PrebuiltDesktop/143febb8-12dc-4bf7-9607-efc0983ec160.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7K-25"
-    ],
+    "part_numbers": ["Titan-7K-25"],
     "series": "Titan 7",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/143febb8-12dc-4bf7-9607-efc0983ec160.json
+++ b/open-db/PrebuiltDesktop/143febb8-12dc-4bf7-9607-efc0983ec160.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "143febb8-12dc-4bf7-9607-efc0983ec160",
+  "metadata": {
+    "name": "Titan 7 - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7K-25"
+    ],
+    "series": "Titan 7",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7?variant=51950793359661"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131959",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793359661",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/1449e391-19ba-41ed-b5eb-47e0a2b87f0b.json
+++ b/open-db/PrebuiltDesktop/1449e391-19ba-41ed-b5eb-47e0a2b87f0b.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "1449e391-19ba-41ed-b5eb-47e0a2b87f0b",
+  "metadata": {
+    "name": "Titan 3 - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3I-25"
+    ],
+    "series": "Titan 3",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3?variant=51950766424365"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131737",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950766424365",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/1449e391-19ba-41ed-b5eb-47e0a2b87f0b.json
+++ b/open-db/PrebuiltDesktop/1449e391-19ba-41ed-b5eb-47e0a2b87f0b.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3I-25"
-    ],
+    "part_numbers": ["Titan-3I-25"],
     "series": "Titan 3",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/18490750-e3f5-4b15-8b16-a55157d14300.json
+++ b/open-db/PrebuiltDesktop/18490750-e3f5-4b15-8b16-a55157d14300.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7L-25"
-    ],
+    "part_numbers": ["Omega-7L-25"],
     "series": "Omega 7",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/18490750-e3f5-4b15-8b16-a55157d14300.json
+++ b/open-db/PrebuiltDesktop/18490750-e3f5-4b15-8b16-a55157d14300.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "18490750-e3f5-4b15-8b16-a55157d14300",
+  "metadata": {
+    "name": "Omega 7 - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7L-25"
+    ],
+    "series": "Omega 7",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7?variant=51950792966445"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132260",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792966445",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/19b20818-efe7-423f-8fd3-3eda84806117.json
+++ b/open-db/PrebuiltDesktop/19b20818-efe7-423f-8fd3-3eda84806117.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 Bundle - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3I2-25"
-    ],
+    "part_numbers": ["Omega-3I2-25"],
     "series": "Omega 3 Bundle",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/19b20818-efe7-423f-8fd3-3eda84806117.json
+++ b/open-db/PrebuiltDesktop/19b20818-efe7-423f-8fd3-3eda84806117.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "19b20818-efe7-423f-8fd3-3eda84806117",
+  "metadata": {
+    "name": "Omega 3 Bundle - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3I2-25"
+    ],
+    "series": "Omega 3 Bundle",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3-bundle?variant=51950791754029"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134233",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791754029",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/1b732785-ad59-44c8-8541-7abe31390ac8.json
+++ b/open-db/PrebuiltDesktop/1b732785-ad59-44c8-8541-7abe31390ac8.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "1b732785-ad59-44c8-8541-7abe31390ac8",
+  "metadata": {
+    "name": "Omega 7 - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7I-25"
+    ],
+    "series": "Omega 7",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7?variant=51950792868141"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132239",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792868141",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/1b732785-ad59-44c8-8541-7abe31390ac8.json
+++ b/open-db/PrebuiltDesktop/1b732785-ad59-44c8-8541-7abe31390ac8.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7I-25"
-    ],
+    "part_numbers": ["Omega-7I-25"],
     "series": "Omega 7",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/1d9df3c5-d59a-4a0a-978f-9dbf50f51537.json
+++ b/open-db/PrebuiltDesktop/1d9df3c5-d59a-4a0a-978f-9dbf50f51537.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3I-26"
-    ],
+    "part_numbers": ["Nova-3I-26"],
     "series": "Nova 3",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/1d9df3c5-d59a-4a0a-978f-9dbf50f51537.json
+++ b/open-db/PrebuiltDesktop/1d9df3c5-d59a-4a0a-978f-9dbf50f51537.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "1d9df3c5-d59a-4a0a-978f-9dbf50f51537",
+  "metadata": {
+    "name": "Nova 3 - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3I-26"
+    ],
+    "series": "Nova 3",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3?variant=51950791295277"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "788362237080",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3I-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791295277",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/21b7ea7c-29ba-4d5a-9a69-1726ec2e847b.json
+++ b/open-db/PrebuiltDesktop/21b7ea7c-29ba-4d5a-9a69-1726ec2e847b.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "21b7ea7c-29ba-4d5a-9a69-1726ec2e847b",
+  "metadata": {
+    "name": "Titan 3 Bundle - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3M2-25"
+    ],
+    "series": "Titan 3 Bundle",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3-bundle?variant=51950792409389"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133977",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3M2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792409389",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/21b7ea7c-29ba-4d5a-9a69-1726ec2e847b.json
+++ b/open-db/PrebuiltDesktop/21b7ea7c-29ba-4d5a-9a69-1726ec2e847b.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 Bundle - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3M2-25"
-    ],
+    "part_numbers": ["Titan-3M2-25"],
     "series": "Titan 3 Bundle",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/249e425e-6b12-4845-83e6-196ea61b8670.json
+++ b/open-db/PrebuiltDesktop/249e425e-6b12-4845-83e6-196ea61b8670.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "249e425e-6b12-4845-83e6-196ea61b8670",
+  "metadata": {
+    "name": "Nova 5 Bundle - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5J2-26"
+    ],
+    "series": "Nova 5 Bundle",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5-bundle?variant=51950790738221"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569027",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5J2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790738221",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/249e425e-6b12-4845-83e6-196ea61b8670.json
+++ b/open-db/PrebuiltDesktop/249e425e-6b12-4845-83e6-196ea61b8670.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 Bundle - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5J2-26"
-    ],
+    "part_numbers": ["Nova-5J2-26"],
     "series": "Nova 5 Bundle",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/26acb184-1229-4b7f-a07b-1dcd2d1bc9a9.json
+++ b/open-db/PrebuiltDesktop/26acb184-1229-4b7f-a07b-1dcd2d1bc9a9.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 Bundle - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7L2-25"
-    ],
+    "part_numbers": ["Omega-7L2-25"],
     "series": "Omega 7 Bundle",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/26acb184-1229-4b7f-a07b-1dcd2d1bc9a9.json
+++ b/open-db/PrebuiltDesktop/26acb184-1229-4b7f-a07b-1dcd2d1bc9a9.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "26acb184-1229-4b7f-a07b-1dcd2d1bc9a9",
+  "metadata": {
+    "name": "Omega 7 Bundle - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7L2-25"
+    ],
+    "series": "Omega 7 Bundle",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7-bundle?variant=51950791590189"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134462",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791590189",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/278aa29a-ce9a-493f-a270-1450fa072959.json
+++ b/open-db/PrebuiltDesktop/278aa29a-ce9a-493f-a270-1450fa072959.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7L-25"
-    ],
+    "part_numbers": ["Titan-7L-25"],
     "series": "Titan 7",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/278aa29a-ce9a-493f-a270-1450fa072959.json
+++ b/open-db/PrebuiltDesktop/278aa29a-ce9a-493f-a270-1450fa072959.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "278aa29a-ce9a-493f-a270-1450fa072959",
+  "metadata": {
+    "name": "Titan 7 - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7L-25"
+    ],
+    "series": "Titan 7",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7?variant=51950793392429"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131966",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793392429",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/27f719e3-4203-455d-b47f-6cd120dccef7.json
+++ b/open-db/PrebuiltDesktop/27f719e3-4203-455d-b47f-6cd120dccef7.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "27f719e3-4203-455d-b47f-6cd120dccef7",
+  "metadata": {
+    "name": "Omega 7 Bundle - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7J2-25"
+    ],
+    "series": "Omega 7 Bundle",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7-bundle?variant=51950791524653"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134448",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791524653",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/27f719e3-4203-455d-b47f-6cd120dccef7.json
+++ b/open-db/PrebuiltDesktop/27f719e3-4203-455d-b47f-6cd120dccef7.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 Bundle - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7J2-25"
-    ],
+    "part_numbers": ["Omega-7J2-25"],
     "series": "Omega 7 Bundle",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/29c163df-c91e-4846-b389-dda6535c13c8.json
+++ b/open-db/PrebuiltDesktop/29c163df-c91e-4846-b389-dda6535c13c8.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "29c163df-c91e-4846-b389-dda6535c13c8",
+  "metadata": {
+    "name": "Apollo 5 - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5I-25"
+    ],
+    "series": "Apollo 5",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5?variant=51950793851181"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131539",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793851181",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/29c163df-c91e-4846-b389-dda6535c13c8.json
+++ b/open-db/PrebuiltDesktop/29c163df-c91e-4846-b389-dda6535c13c8.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5I-25"
-    ],
+    "part_numbers": ["Apollo-5I-25"],
     "series": "Apollo 5",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/2e1a953c-ead7-4a3c-aa91-372f7fba1a9e.json
+++ b/open-db/PrebuiltDesktop/2e1a953c-ead7-4a3c-aa91-372f7fba1a9e.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 Bundle - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3J2-25"
-    ],
+    "part_numbers": ["Titan-3J2-25"],
     "series": "Titan 3 Bundle",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/2e1a953c-ead7-4a3c-aa91-372f7fba1a9e.json
+++ b/open-db/PrebuiltDesktop/2e1a953c-ead7-4a3c-aa91-372f7fba1a9e.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "2e1a953c-ead7-4a3c-aa91-372f7fba1a9e",
+  "metadata": {
+    "name": "Titan 3 Bundle - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3J2-25"
+    ],
+    "series": "Titan 3 Bundle",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3-bundle?variant=51950792311085"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133946",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792311085",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/2f681fa8-e456-4fcd-b7f1-9632d29a14af.json
+++ b/open-db/PrebuiltDesktop/2f681fa8-e456-4fcd-b7f1-9632d29a14af.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5K-25"
-    ],
+    "part_numbers": ["Apollo-5K-25"],
     "series": "Apollo 5",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/2f681fa8-e456-4fcd-b7f1-9632d29a14af.json
+++ b/open-db/PrebuiltDesktop/2f681fa8-e456-4fcd-b7f1-9632d29a14af.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "2f681fa8-e456-4fcd-b7f1-9632d29a14af",
+  "metadata": {
+    "name": "Apollo 5 - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5K-25"
+    ],
+    "series": "Apollo 5",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5?variant=51950793916717"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131553",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793916717",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/311ca63d-3b27-4f2b-86b2-fb825b7fb272.json
+++ b/open-db/PrebuiltDesktop/311ca63d-3b27-4f2b-86b2-fb825b7fb272.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7I-26"
-    ],
+    "part_numbers": ["Nova-7I-26"],
     "series": "Nova 7",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/311ca63d-3b27-4f2b-86b2-fb825b7fb272.json
+++ b/open-db/PrebuiltDesktop/311ca63d-3b27-4f2b-86b2-fb825b7fb272.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "311ca63d-3b27-4f2b-86b2-fb825b7fb272",
+  "metadata": {
+    "name": "Nova 7 - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7I-26"
+    ],
+    "series": "Nova 7",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7?variant=51950791033133"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568815",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7I-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791033133",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/32f51605-000d-4d25-876d-72273e9fd2ce.json
+++ b/open-db/PrebuiltDesktop/32f51605-000d-4d25-876d-72273e9fd2ce.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 Bundle - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7I2-25"
-    ],
+    "part_numbers": ["Titan-7I2-25"],
     "series": "Titan 7 Bundle",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/32f51605-000d-4d25-876d-72273e9fd2ce.json
+++ b/open-db/PrebuiltDesktop/32f51605-000d-4d25-876d-72273e9fd2ce.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "32f51605-000d-4d25-876d-72273e9fd2ce",
+  "metadata": {
+    "name": "Titan 7 Bundle - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7I2-25"
+    ],
+    "series": "Titan 7 Bundle",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7-bundle?variant=51950791917869"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134134",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791917869",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/34e5fabd-5d3d-4fba-b01b-032c28206da1.json
+++ b/open-db/PrebuiltDesktop/34e5fabd-5d3d-4fba-b01b-032c28206da1.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "34e5fabd-5d3d-4fba-b01b-032c28206da1",
+  "metadata": {
+    "name": "Titan 3 - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3J-25"
+    ],
+    "series": "Titan 3",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3?variant=51950765900077"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131744",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950765900077",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/34e5fabd-5d3d-4fba-b01b-032c28206da1.json
+++ b/open-db/PrebuiltDesktop/34e5fabd-5d3d-4fba-b01b-032c28206da1.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3J-25"
-    ],
+    "part_numbers": ["Titan-3J-25"],
     "series": "Titan 3",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/35ad58a6-62a6-43e7-9289-01df2d1df0ed.json
+++ b/open-db/PrebuiltDesktop/35ad58a6-62a6-43e7-9289-01df2d1df0ed.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3N-26"
-    ],
+    "part_numbers": ["Nova-3N-26"],
     "series": "Nova 3",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/35ad58a6-62a6-43e7-9289-01df2d1df0ed.json
+++ b/open-db/PrebuiltDesktop/35ad58a6-62a6-43e7-9289-01df2d1df0ed.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "35ad58a6-62a6-43e7-9289-01df2d1df0ed",
+  "metadata": {
+    "name": "Nova 3 - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3N-26"
+    ],
+    "series": "Nova 3",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3?variant=51950791459117"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "788362237134",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3N-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791459117",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/39674a85-26a5-4e00-8868-35008623a0c7.json
+++ b/open-db/PrebuiltDesktop/39674a85-26a5-4e00-8868-35008623a0c7.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "39674a85-26a5-4e00-8868-35008623a0c7",
+  "metadata": {
+    "name": "Nova 5 Bundle - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5I2-26"
+    ],
+    "series": "Nova 5 Bundle",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5-bundle?variant=51950790705453"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569010",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5I2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790705453",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/39674a85-26a5-4e00-8868-35008623a0c7.json
+++ b/open-db/PrebuiltDesktop/39674a85-26a5-4e00-8868-35008623a0c7.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 Bundle - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5I2-26"
-    ],
+    "part_numbers": ["Nova-5I2-26"],
     "series": "Nova 5 Bundle",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/3b67e9cf-d9c4-4cae-8eaa-8fefe1346ecc.json
+++ b/open-db/PrebuiltDesktop/3b67e9cf-d9c4-4cae-8eaa-8fefe1346ecc.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "3b67e9cf-d9c4-4cae-8eaa-8fefe1346ecc",
+  "metadata": {
+    "name": "Apollo 5 - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5J-25"
+    ],
+    "series": "Apollo 5",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5?variant=51950793883949"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131546",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793883949",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/3b67e9cf-d9c4-4cae-8eaa-8fefe1346ecc.json
+++ b/open-db/PrebuiltDesktop/3b67e9cf-d9c4-4cae-8eaa-8fefe1346ecc.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5J-25"
-    ],
+    "part_numbers": ["Apollo-5J-25"],
     "series": "Apollo 5",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/3e2a6ca7-5715-439e-baaa-b2858f3ad883.json
+++ b/open-db/PrebuiltDesktop/3e2a6ca7-5715-439e-baaa-b2858f3ad883.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "3e2a6ca7-5715-439e-baaa-b2858f3ad883",
+  "metadata": {
+    "name": "Apollo 7 Bundle - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7J2-25"
+    ],
+    "series": "Apollo 7 Bundle",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7-bundle?variant=51950792507693"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133847",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792507693",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/3e2a6ca7-5715-439e-baaa-b2858f3ad883.json
+++ b/open-db/PrebuiltDesktop/3e2a6ca7-5715-439e-baaa-b2858f3ad883.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 Bundle - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7J2-25"
-    ],
+    "part_numbers": ["Apollo-7J2-25"],
     "series": "Apollo 7 Bundle",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/4b61a722-21eb-43d7-803d-de772fedcfad.json
+++ b/open-db/PrebuiltDesktop/4b61a722-21eb-43d7-803d-de772fedcfad.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "4b61a722-21eb-43d7-803d-de772fedcfad",
+  "metadata": {
+    "name": "Nova 5 - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5L-26"
+    ],
+    "series": "Nova 5",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5?variant=51950791262509"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568747",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5L-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791262509",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/4b61a722-21eb-43d7-803d-de772fedcfad.json
+++ b/open-db/PrebuiltDesktop/4b61a722-21eb-43d7-803d-de772fedcfad.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5L-26"
-    ],
+    "part_numbers": ["Nova-5L-26"],
     "series": "Nova 5",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/52e06d18-d30b-4110-84fd-c86b0b3c6182.json
+++ b/open-db/PrebuiltDesktop/52e06d18-d30b-4110-84fd-c86b0b3c6182.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 Bundle - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3K2-25"
-    ],
+    "part_numbers": ["Titan-3K2-25"],
     "series": "Titan 3 Bundle",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/52e06d18-d30b-4110-84fd-c86b0b3c6182.json
+++ b/open-db/PrebuiltDesktop/52e06d18-d30b-4110-84fd-c86b0b3c6182.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "52e06d18-d30b-4110-84fd-c86b0b3c6182",
+  "metadata": {
+    "name": "Titan 3 Bundle - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3K2-25"
+    ],
+    "series": "Titan 3 Bundle",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3-bundle?variant=51950792343853"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133953",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792343853",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/53287bbb-2f05-4a73-857d-d1db9cf9781a.json
+++ b/open-db/PrebuiltDesktop/53287bbb-2f05-4a73-857d-d1db9cf9781a.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "53287bbb-2f05-4a73-857d-d1db9cf9781a",
+  "metadata": {
+    "name": "Omega 5 - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5I-25"
+    ],
+    "series": "Omega 5",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5?variant=51950792999213"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132130",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792999213",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/53287bbb-2f05-4a73-857d-d1db9cf9781a.json
+++ b/open-db/PrebuiltDesktop/53287bbb-2f05-4a73-857d-d1db9cf9781a.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5I-25"
-    ],
+    "part_numbers": ["Omega-5I-25"],
     "series": "Omega 5",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/5b81c3e5-6bac-455f-ba6b-ff4a9999a5cc.json
+++ b/open-db/PrebuiltDesktop/5b81c3e5-6bac-455f-ba6b-ff4a9999a5cc.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 Bundle - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5J2-25"
-    ],
+    "part_numbers": ["Omega-5J2-25"],
     "series": "Omega 5 Bundle",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/5b81c3e5-6bac-455f-ba6b-ff4a9999a5cc.json
+++ b/open-db/PrebuiltDesktop/5b81c3e5-6bac-455f-ba6b-ff4a9999a5cc.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "5b81c3e5-6bac-455f-ba6b-ff4a9999a5cc",
+  "metadata": {
+    "name": "Omega 5 Bundle - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5J2-25"
+    ],
+    "series": "Omega 5 Bundle",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5-bundle?variant=51950791655725"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134349",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791655725",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/5bc7f062-5547-46da-a750-4b2f778e4a35.json
+++ b/open-db/PrebuiltDesktop/5bc7f062-5547-46da-a750-4b2f778e4a35.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 Bundle - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7K2-25"
-    ],
+    "part_numbers": ["Omega-7K2-25"],
     "series": "Omega 7 Bundle",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/5bc7f062-5547-46da-a750-4b2f778e4a35.json
+++ b/open-db/PrebuiltDesktop/5bc7f062-5547-46da-a750-4b2f778e4a35.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "5bc7f062-5547-46da-a750-4b2f778e4a35",
+  "metadata": {
+    "name": "Omega 7 Bundle - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7K2-25"
+    ],
+    "series": "Omega 7 Bundle",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7-bundle?variant=51950791557421"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134455",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791557421",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/5bd409ad-7a8e-4f57-932b-36125f47cc4a.json
+++ b/open-db/PrebuiltDesktop/5bd409ad-7a8e-4f57-932b-36125f47cc4a.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5I-25"
-    ],
+    "part_numbers": ["Titan-5I-25"],
     "series": "Titan 5",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/5bd409ad-7a8e-4f57-932b-36125f47cc4a.json
+++ b/open-db/PrebuiltDesktop/5bd409ad-7a8e-4f57-932b-36125f47cc4a.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "5bd409ad-7a8e-4f57-932b-36125f47cc4a",
+  "metadata": {
+    "name": "Titan 5 - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5I-25"
+    ],
+    "series": "Titan 5",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5?variant=51950793425197"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131836",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793425197",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/5c51b426-a6ae-42fa-86b4-20fa82eabc1e.json
+++ b/open-db/PrebuiltDesktop/5c51b426-a6ae-42fa-86b4-20fa82eabc1e.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 Bundle - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7K2-25"
-    ],
+    "part_numbers": ["Apollo-7K2-25"],
     "series": "Apollo 7 Bundle",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/5c51b426-a6ae-42fa-86b4-20fa82eabc1e.json
+++ b/open-db/PrebuiltDesktop/5c51b426-a6ae-42fa-86b4-20fa82eabc1e.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "5c51b426-a6ae-42fa-86b4-20fa82eabc1e",
+  "metadata": {
+    "name": "Apollo 7 Bundle - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7K2-25"
+    ],
+    "series": "Apollo 7 Bundle",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7-bundle?variant=51950792540461"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133854",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792540461",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/5fea568b-8e6a-46f2-be5b-98828d4d052a.json
+++ b/open-db/PrebuiltDesktop/5fea568b-8e6a-46f2-be5b-98828d4d052a.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7L-26"
-    ],
+    "part_numbers": ["Nova-7L-26"],
     "series": "Nova 7",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/5fea568b-8e6a-46f2-be5b-98828d4d052a.json
+++ b/open-db/PrebuiltDesktop/5fea568b-8e6a-46f2-be5b-98828d4d052a.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "5fea568b-8e6a-46f2-be5b-98828d4d052a",
+  "metadata": {
+    "name": "Nova 7 - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7L-26"
+    ],
+    "series": "Nova 7",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7?variant=51950791131437"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568846",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7L-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791131437",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/611ebf41-ff64-4a6d-851f-c4ef7c84bb75.json
+++ b/open-db/PrebuiltDesktop/611ebf41-ff64-4a6d-851f-c4ef7c84bb75.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7K-25"
-    ],
+    "part_numbers": ["Apollo-7K-25"],
     "series": "Apollo 7",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/611ebf41-ff64-4a6d-851f-c4ef7c84bb75.json
+++ b/open-db/PrebuiltDesktop/611ebf41-ff64-4a6d-851f-c4ef7c84bb75.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "611ebf41-ff64-4a6d-851f-c4ef7c84bb75",
+  "metadata": {
+    "name": "Apollo 7 - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7K-25"
+    ],
+    "series": "Apollo 7",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7?variant=51950793687341"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131652",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793687341",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/624e2084-d9b4-4be0-b693-d9b1e07626fa.json
+++ b/open-db/PrebuiltDesktop/624e2084-d9b4-4be0-b693-d9b1e07626fa.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "624e2084-d9b4-4be0-b693-d9b1e07626fa",
+  "metadata": {
+    "name": "Apollo 5 Bundle - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5M2-25"
+    ],
+    "series": "Apollo 5 Bundle",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5-bundle?variant=51950792802605"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133779",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5M2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792802605",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/624e2084-d9b4-4be0-b693-d9b1e07626fa.json
+++ b/open-db/PrebuiltDesktop/624e2084-d9b4-4be0-b693-d9b1e07626fa.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 Bundle - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5M2-25"
-    ],
+    "part_numbers": ["Apollo-5M2-25"],
     "series": "Apollo 5 Bundle",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/633ca7f9-dfc2-4c07-8987-a991435efd1b.json
+++ b/open-db/PrebuiltDesktop/633ca7f9-dfc2-4c07-8987-a991435efd1b.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "633ca7f9-dfc2-4c07-8987-a991435efd1b",
+  "metadata": {
+    "name": "Titan 3 - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3N-25"
+    ],
+    "series": "Titan 3",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3?variant=51950766031149"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131782",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3N-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950766031149",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/633ca7f9-dfc2-4c07-8987-a991435efd1b.json
+++ b/open-db/PrebuiltDesktop/633ca7f9-dfc2-4c07-8987-a991435efd1b.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3N-25"
-    ],
+    "part_numbers": ["Titan-3N-25"],
     "series": "Titan 3",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/636d495a-2442-4e2c-8f46-3be3efa9345b.json
+++ b/open-db/PrebuiltDesktop/636d495a-2442-4e2c-8f46-3be3efa9345b.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "636d495a-2442-4e2c-8f46-3be3efa9345b",
+  "metadata": {
+    "name": "Apollo 7 Bundle - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7L2-25"
+    ],
+    "series": "Apollo 7 Bundle",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7-bundle?variant=51950792573229"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133861",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792573229",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/636d495a-2442-4e2c-8f46-3be3efa9345b.json
+++ b/open-db/PrebuiltDesktop/636d495a-2442-4e2c-8f46-3be3efa9345b.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 Bundle - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7L2-25"
-    ],
+    "part_numbers": ["Apollo-7L2-25"],
     "series": "Apollo 7 Bundle",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/6661dd44-358a-4de5-8f24-80cfc0e3e6be.json
+++ b/open-db/PrebuiltDesktop/6661dd44-358a-4de5-8f24-80cfc0e3e6be.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 Bundle - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3N2-26"
-    ],
+    "part_numbers": ["Nova-3N2-26"],
     "series": "Nova 3 Bundle",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/6661dd44-358a-4de5-8f24-80cfc0e3e6be.json
+++ b/open-db/PrebuiltDesktop/6661dd44-358a-4de5-8f24-80cfc0e3e6be.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "6661dd44-358a-4de5-8f24-80cfc0e3e6be",
+  "metadata": {
+    "name": "Nova 3 Bundle - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3N2-26"
+    ],
+    "series": "Nova 3 Bundle",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3-bundle?variant=51950791000365"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568969",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3N2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791000365",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/6ac9f6b7-72b2-4d5f-9956-97cfce410d25.json
+++ b/open-db/PrebuiltDesktop/6ac9f6b7-72b2-4d5f-9956-97cfce410d25.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 Bundle - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7L2-25"
-    ],
+    "part_numbers": ["Titan-7L2-25"],
     "series": "Titan 7 Bundle",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/6ac9f6b7-72b2-4d5f-9956-97cfce410d25.json
+++ b/open-db/PrebuiltDesktop/6ac9f6b7-72b2-4d5f-9956-97cfce410d25.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "6ac9f6b7-72b2-4d5f-9956-97cfce410d25",
+  "metadata": {
+    "name": "Titan 7 Bundle - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7L2-25"
+    ],
+    "series": "Titan 7 Bundle",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7-bundle?variant=51950792016173"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134165",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792016173",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/6bdbffca-d527-4a29-9966-8fced9597775.json
+++ b/open-db/PrebuiltDesktop/6bdbffca-d527-4a29-9966-8fced9597775.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "6bdbffca-d527-4a29-9966-8fced9597775",
+  "metadata": {
+    "name": "Apollo 7 Bundle - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7I2-25"
+    ],
+    "series": "Apollo 7 Bundle",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7-bundle?variant=51950792474925"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133830",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792474925",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/6bdbffca-d527-4a29-9966-8fced9597775.json
+++ b/open-db/PrebuiltDesktop/6bdbffca-d527-4a29-9966-8fced9597775.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 Bundle - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7I2-25"
-    ],
+    "part_numbers": ["Apollo-7I2-25"],
     "series": "Apollo 7 Bundle",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/6e1c34a6-8f4d-4bc7-af41-d27c23928276.json
+++ b/open-db/PrebuiltDesktop/6e1c34a6-8f4d-4bc7-af41-d27c23928276.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "6e1c34a6-8f4d-4bc7-af41-d27c23928276",
+  "metadata": {
+    "name": "Titan 5 - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5J-25"
+    ],
+    "series": "Titan 5",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5?variant=51950793457965"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131843",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793457965",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/6e1c34a6-8f4d-4bc7-af41-d27c23928276.json
+++ b/open-db/PrebuiltDesktop/6e1c34a6-8f4d-4bc7-af41-d27c23928276.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5J-25"
-    ],
+    "part_numbers": ["Titan-5J-25"],
     "series": "Titan 5",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/707a7bf5-1bb7-49f9-b34e-ba7291edbec7.json
+++ b/open-db/PrebuiltDesktop/707a7bf5-1bb7-49f9-b34e-ba7291edbec7.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "707a7bf5-1bb7-49f9-b34e-ba7291edbec7",
+  "metadata": {
+    "name": "Omega 7 - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7J-25"
+    ],
+    "series": "Omega 7",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7?variant=51950792900909"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132246",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792900909",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/707a7bf5-1bb7-49f9-b34e-ba7291edbec7.json
+++ b/open-db/PrebuiltDesktop/707a7bf5-1bb7-49f9-b34e-ba7291edbec7.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7J-25"
-    ],
+    "part_numbers": ["Omega-7J-25"],
     "series": "Omega 7",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/76806900-7a54-442d-bac2-87409c1d551e.json
+++ b/open-db/PrebuiltDesktop/76806900-7a54-442d-bac2-87409c1d551e.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7M-25"
-    ],
+    "part_numbers": ["Apollo-7M-25"],
     "series": "Apollo 7",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/76806900-7a54-442d-bac2-87409c1d551e.json
+++ b/open-db/PrebuiltDesktop/76806900-7a54-442d-bac2-87409c1d551e.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "76806900-7a54-442d-bac2-87409c1d551e",
+  "metadata": {
+    "name": "Apollo 7 - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7M-25"
+    ],
+    "series": "Apollo 7",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7?variant=51950793752877"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131676",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7M-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793752877",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/7b28af70-cb41-46cb-a3ee-5dccce2f4700.json
+++ b/open-db/PrebuiltDesktop/7b28af70-cb41-46cb-a3ee-5dccce2f4700.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "7b28af70-cb41-46cb-a3ee-5dccce2f4700",
+  "metadata": {
+    "name": "Titan 5 Bundle - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5L2-25"
+    ],
+    "series": "Titan 5 Bundle",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5-bundle?variant=51950792180013"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134066",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792180013",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/7b28af70-cb41-46cb-a3ee-5dccce2f4700.json
+++ b/open-db/PrebuiltDesktop/7b28af70-cb41-46cb-a3ee-5dccce2f4700.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 Bundle - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5L2-25"
-    ],
+    "part_numbers": ["Titan-5L2-25"],
     "series": "Titan 5 Bundle",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/7dbdee9b-85f2-41d3-ac72-4972f54dbadd.json
+++ b/open-db/PrebuiltDesktop/7dbdee9b-85f2-41d3-ac72-4972f54dbadd.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "7dbdee9b-85f2-41d3-ac72-4972f54dbadd",
+  "metadata": {
+    "name": "Titan 5 Bundle - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5K2-25"
+    ],
+    "series": "Titan 5 Bundle",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5-bundle?variant=51950792147245"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134059",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792147245",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/7dbdee9b-85f2-41d3-ac72-4972f54dbadd.json
+++ b/open-db/PrebuiltDesktop/7dbdee9b-85f2-41d3-ac72-4972f54dbadd.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 Bundle - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5K2-25"
-    ],
+    "part_numbers": ["Titan-5K2-25"],
     "series": "Titan 5 Bundle",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/80f76e20-847e-445c-9279-cf317afe4510.json
+++ b/open-db/PrebuiltDesktop/80f76e20-847e-445c-9279-cf317afe4510.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "80f76e20-847e-445c-9279-cf317afe4510",
+  "metadata": {
+    "name": "Titan 3 - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3K-25"
+    ],
+    "series": "Titan 3",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3?variant=51950765932845"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131751",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950765932845",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/80f76e20-847e-445c-9279-cf317afe4510.json
+++ b/open-db/PrebuiltDesktop/80f76e20-847e-445c-9279-cf317afe4510.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3K-25"
-    ],
+    "part_numbers": ["Titan-3K-25"],
     "series": "Titan 3",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/81278959-6dbe-45d7-bccc-54d4380612c6.json
+++ b/open-db/PrebuiltDesktop/81278959-6dbe-45d7-bccc-54d4380612c6.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 Bundle - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3J2-26"
-    ],
+    "part_numbers": ["Nova-3J2-26"],
     "series": "Nova 3 Bundle",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/81278959-6dbe-45d7-bccc-54d4380612c6.json
+++ b/open-db/PrebuiltDesktop/81278959-6dbe-45d7-bccc-54d4380612c6.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "81278959-6dbe-45d7-bccc-54d4380612c6",
+  "metadata": {
+    "name": "Nova 3 Bundle - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3J2-26"
+    ],
+    "series": "Nova 3 Bundle",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3-bundle?variant=51950790869293"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568921",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3J2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790869293",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/8272b5b5-943b-4aa4-a1e9-b136e4482b1d.json
+++ b/open-db/PrebuiltDesktop/8272b5b5-943b-4aa4-a1e9-b136e4482b1d.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "8272b5b5-943b-4aa4-a1e9-b136e4482b1d",
+  "metadata": {
+    "name": "Nova 5 - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5I-26"
+    ],
+    "series": "Nova 5",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5?variant=51950791164205"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568716",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5I-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791164205",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/8272b5b5-943b-4aa4-a1e9-b136e4482b1d.json
+++ b/open-db/PrebuiltDesktop/8272b5b5-943b-4aa4-a1e9-b136e4482b1d.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5I-26"
-    ],
+    "part_numbers": ["Nova-5I-26"],
     "series": "Nova 5",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/832fe27f-c5cc-4e19-9df0-d2973631e1e7.json
+++ b/open-db/PrebuiltDesktop/832fe27f-c5cc-4e19-9df0-d2973631e1e7.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "832fe27f-c5cc-4e19-9df0-d2973631e1e7",
+  "metadata": {
+    "name": "Apollo 5 Bundle - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5N2-25"
+    ],
+    "series": "Apollo 5 Bundle",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5-bundle?variant=51950792835373"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133786",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5N2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792835373",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/832fe27f-c5cc-4e19-9df0-d2973631e1e7.json
+++ b/open-db/PrebuiltDesktop/832fe27f-c5cc-4e19-9df0-d2973631e1e7.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 Bundle - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5N2-25"
-    ],
+    "part_numbers": ["Apollo-5N2-25"],
     "series": "Apollo 5 Bundle",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/83834e43-0984-4240-8d0b-c2ec0e30ce07.json
+++ b/open-db/PrebuiltDesktop/83834e43-0984-4240-8d0b-c2ec0e30ce07.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "83834e43-0984-4240-8d0b-c2ec0e30ce07",
+  "metadata": {
+    "name": "Apollo 7 Bundle - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7M2-25"
+    ],
+    "series": "Apollo 7 Bundle",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7-bundle?variant=51950792605997"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133878",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7M2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792605997",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/83834e43-0984-4240-8d0b-c2ec0e30ce07.json
+++ b/open-db/PrebuiltDesktop/83834e43-0984-4240-8d0b-c2ec0e30ce07.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 Bundle - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7M2-25"
-    ],
+    "part_numbers": ["Apollo-7M2-25"],
     "series": "Apollo 7 Bundle",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/84ddd1f7-a6d6-4636-aa10-e9d3e3f9acf9.json
+++ b/open-db/PrebuiltDesktop/84ddd1f7-a6d6-4636-aa10-e9d3e3f9acf9.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "84ddd1f7-a6d6-4636-aa10-e9d3e3f9acf9",
+  "metadata": {
+    "name": "Omega 5 Bundle - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5K2-25"
+    ],
+    "series": "Omega 5 Bundle",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5-bundle?variant=51950791688493"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134356",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791688493",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/84ddd1f7-a6d6-4636-aa10-e9d3e3f9acf9.json
+++ b/open-db/PrebuiltDesktop/84ddd1f7-a6d6-4636-aa10-e9d3e3f9acf9.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 Bundle - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5K2-25"
-    ],
+    "part_numbers": ["Omega-5K2-25"],
     "series": "Omega 5 Bundle",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/872e7a1a-725c-470d-a907-9f07b0ebbc7d.json
+++ b/open-db/PrebuiltDesktop/872e7a1a-725c-470d-a907-9f07b0ebbc7d.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "872e7a1a-725c-470d-a907-9f07b0ebbc7d",
+  "metadata": {
+    "name": "Omega 7 Bundle - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7I2-25"
+    ],
+    "series": "Omega 7 Bundle",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7-bundle?variant=51950791491885"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134431",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791491885",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/872e7a1a-725c-470d-a907-9f07b0ebbc7d.json
+++ b/open-db/PrebuiltDesktop/872e7a1a-725c-470d-a907-9f07b0ebbc7d.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 Bundle - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7I2-25"
-    ],
+    "part_numbers": ["Omega-7I2-25"],
     "series": "Omega 7 Bundle",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/87aeba33-07b0-4173-a7f1-e67803998725.json
+++ b/open-db/PrebuiltDesktop/87aeba33-07b0-4173-a7f1-e67803998725.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7I-25"
-    ],
+    "part_numbers": ["Apollo-7I-25"],
     "series": "Apollo 7",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/87aeba33-07b0-4173-a7f1-e67803998725.json
+++ b/open-db/PrebuiltDesktop/87aeba33-07b0-4173-a7f1-e67803998725.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "87aeba33-07b0-4173-a7f1-e67803998725",
+  "metadata": {
+    "name": "Apollo 7 - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7I-25"
+    ],
+    "series": "Apollo 7",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7?variant=51950793621805"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131638",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793621805",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/8ca3b6e2-595d-4ab7-b635-d5c9d7c8f8f7.json
+++ b/open-db/PrebuiltDesktop/8ca3b6e2-595d-4ab7-b635-d5c9d7c8f8f7.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3I-25"
-    ],
+    "part_numbers": ["Omega-3I-25"],
     "series": "Omega 3",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/8ca3b6e2-595d-4ab7-b635-d5c9d7c8f8f7.json
+++ b/open-db/PrebuiltDesktop/8ca3b6e2-595d-4ab7-b635-d5c9d7c8f8f7.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "8ca3b6e2-595d-4ab7-b635-d5c9d7c8f8f7",
+  "metadata": {
+    "name": "Omega 3 - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3I-25"
+    ],
+    "series": "Omega 3",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3?variant=51950793130285"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132031",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793130285",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/8dc0f038-8d47-45a5-a4c5-5aba33709708.json
+++ b/open-db/PrebuiltDesktop/8dc0f038-8d47-45a5-a4c5-5aba33709708.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5L-25"
-    ],
+    "part_numbers": ["Apollo-5L-25"],
     "series": "Apollo 5",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/8dc0f038-8d47-45a5-a4c5-5aba33709708.json
+++ b/open-db/PrebuiltDesktop/8dc0f038-8d47-45a5-a4c5-5aba33709708.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "8dc0f038-8d47-45a5-a4c5-5aba33709708",
+  "metadata": {
+    "name": "Apollo 5 - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5L-25"
+    ],
+    "series": "Apollo 5",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5?variant=51950793949485"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131560",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793949485",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/903e18ca-d748-4f12-a3b9-2607157ce770.json
+++ b/open-db/PrebuiltDesktop/903e18ca-d748-4f12-a3b9-2607157ce770.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "903e18ca-d748-4f12-a3b9-2607157ce770",
+  "metadata": {
+    "name": "Titan 5 Bundle - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5I2-25"
+    ],
+    "series": "Titan 5 Bundle",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5-bundle?variant=51950792081709"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134035",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792081709",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/903e18ca-d748-4f12-a3b9-2607157ce770.json
+++ b/open-db/PrebuiltDesktop/903e18ca-d748-4f12-a3b9-2607157ce770.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 Bundle - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5I2-25"
-    ],
+    "part_numbers": ["Titan-5I2-25"],
     "series": "Titan 5 Bundle",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/98afd543-3a95-4841-9189-66955bb2dc65.json
+++ b/open-db/PrebuiltDesktop/98afd543-3a95-4841-9189-66955bb2dc65.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "98afd543-3a95-4841-9189-66955bb2dc65",
+  "metadata": {
+    "name": "Nova 3 Bundle - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3K2-26"
+    ],
+    "series": "Nova 3 Bundle",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3-bundle?variant=51950790902061"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568938",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3K2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790902061",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/98afd543-3a95-4841-9189-66955bb2dc65.json
+++ b/open-db/PrebuiltDesktop/98afd543-3a95-4841-9189-66955bb2dc65.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 Bundle - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3K2-26"
-    ],
+    "part_numbers": ["Nova-3K2-26"],
     "series": "Nova 3 Bundle",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/9bb7b35c-b2fe-4b47-ba58-a7953b8bb367.json
+++ b/open-db/PrebuiltDesktop/9bb7b35c-b2fe-4b47-ba58-a7953b8bb367.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3L-25"
-    ],
+    "part_numbers": ["Omega-3L-25"],
     "series": "Omega 3",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/9bb7b35c-b2fe-4b47-ba58-a7953b8bb367.json
+++ b/open-db/PrebuiltDesktop/9bb7b35c-b2fe-4b47-ba58-a7953b8bb367.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "9bb7b35c-b2fe-4b47-ba58-a7953b8bb367",
+  "metadata": {
+    "name": "Omega 3 - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3L-25"
+    ],
+    "series": "Omega 3",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3?variant=51950793228589"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132062",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793228589",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/9e7c3da3-9650-4de7-b0f7-2c2c6eb860f8.json
+++ b/open-db/PrebuiltDesktop/9e7c3da3-9650-4de7-b0f7-2c2c6eb860f8.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "9e7c3da3-9650-4de7-b0f7-2c2c6eb860f8",
+  "metadata": {
+    "name": "Nova 5 Bundle - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5L2-26"
+    ],
+    "series": "Nova 5 Bundle",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5-bundle?variant=51950790803757"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569041",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5L2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790803757",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/9e7c3da3-9650-4de7-b0f7-2c2c6eb860f8.json
+++ b/open-db/PrebuiltDesktop/9e7c3da3-9650-4de7-b0f7-2c2c6eb860f8.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 Bundle - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5L2-26"
-    ],
+    "part_numbers": ["Nova-5L2-26"],
     "series": "Nova 5 Bundle",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/a0377137-fcf2-404a-b257-07c3a647251a.json
+++ b/open-db/PrebuiltDesktop/a0377137-fcf2-404a-b257-07c3a647251a.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5L-25"
-    ],
+    "part_numbers": ["Titan-5L-25"],
     "series": "Titan 5",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/a0377137-fcf2-404a-b257-07c3a647251a.json
+++ b/open-db/PrebuiltDesktop/a0377137-fcf2-404a-b257-07c3a647251a.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "a0377137-fcf2-404a-b257-07c3a647251a",
+  "metadata": {
+    "name": "Titan 5 - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5L-25"
+    ],
+    "series": "Titan 5",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5?variant=51950793523501"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131867",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793523501",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/a0d56488-2830-42cd-bf21-244976173b9b.json
+++ b/open-db/PrebuiltDesktop/a0d56488-2830-42cd-bf21-244976173b9b.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 Bundle - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7N2-25"
-    ],
+    "part_numbers": ["Apollo-7N2-25"],
     "series": "Apollo 7 Bundle",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/a0d56488-2830-42cd-bf21-244976173b9b.json
+++ b/open-db/PrebuiltDesktop/a0d56488-2830-42cd-bf21-244976173b9b.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "a0d56488-2830-42cd-bf21-244976173b9b",
+  "metadata": {
+    "name": "Apollo 7 Bundle - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7N2-25"
+    ],
+    "series": "Apollo 7 Bundle",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7-bundle?variant=51950792638765"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133885",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7N2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792638765",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/a2500bc7-f5a7-4f2d-9d3c-19f85c52bcf2.json
+++ b/open-db/PrebuiltDesktop/a2500bc7-f5a7-4f2d-9d3c-19f85c52bcf2.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "a2500bc7-f5a7-4f2d-9d3c-19f85c52bcf2",
+  "metadata": {
+    "name": "Apollo 5 Bundle - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5J2-25"
+    ],
+    "series": "Apollo 5 Bundle",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5-bundle?variant=51950792704301"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133748",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792704301",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/a2500bc7-f5a7-4f2d-9d3c-19f85c52bcf2.json
+++ b/open-db/PrebuiltDesktop/a2500bc7-f5a7-4f2d-9d3c-19f85c52bcf2.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 Bundle - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5J2-25"
-    ],
+    "part_numbers": ["Apollo-5J2-25"],
     "series": "Apollo 5 Bundle",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/a3795b20-4ead-42ee-a0e9-38925ee6f15f.json
+++ b/open-db/PrebuiltDesktop/a3795b20-4ead-42ee-a0e9-38925ee6f15f.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "a3795b20-4ead-42ee-a0e9-38925ee6f15f",
+  "metadata": {
+    "name": "Nova 7 Bundle - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7I2-26"
+    ],
+    "series": "Nova 7 Bundle",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7-bundle?variant=51950790574381"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569119",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7I2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790574381",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/a3795b20-4ead-42ee-a0e9-38925ee6f15f.json
+++ b/open-db/PrebuiltDesktop/a3795b20-4ead-42ee-a0e9-38925ee6f15f.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 Bundle - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7I2-26"
-    ],
+    "part_numbers": ["Nova-7I2-26"],
     "series": "Nova 7 Bundle",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/a4cd8ff2-45f9-470f-8eed-8a9951ac0b75.json
+++ b/open-db/PrebuiltDesktop/a4cd8ff2-45f9-470f-8eed-8a9951ac0b75.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 5 Bundle - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-5J2-25"
-    ],
+    "part_numbers": ["Titan-5J2-25"],
     "series": "Titan 5 Bundle",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/a4cd8ff2-45f9-470f-8eed-8a9951ac0b75.json
+++ b/open-db/PrebuiltDesktop/a4cd8ff2-45f9-470f-8eed-8a9951ac0b75.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "a4cd8ff2-45f9-470f-8eed-8a9951ac0b75",
+  "metadata": {
+    "name": "Titan 5 Bundle - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-5J2-25"
+    ],
+    "series": "Titan 5 Bundle",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-5-bundle?variant=51950792114477"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134042",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-5J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792114477",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/a6770402-0cc5-4b96-8bd6-907c8c7bce20.json
+++ b/open-db/PrebuiltDesktop/a6770402-0cc5-4b96-8bd6-907c8c7bce20.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "a6770402-0cc5-4b96-8bd6-907c8c7bce20",
+  "metadata": {
+    "name": "Apollo 5 Bundle - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5I2-25"
+    ],
+    "series": "Apollo 5 Bundle",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5-bundle?variant=51950792671533"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133731",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792671533",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/a6770402-0cc5-4b96-8bd6-907c8c7bce20.json
+++ b/open-db/PrebuiltDesktop/a6770402-0cc5-4b96-8bd6-907c8c7bce20.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 Bundle - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5I2-25"
-    ],
+    "part_numbers": ["Apollo-5I2-25"],
     "series": "Apollo 5 Bundle",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/ab4bc375-2042-4614-b0b2-3ef7015c52e9.json
+++ b/open-db/PrebuiltDesktop/ab4bc375-2042-4614-b0b2-3ef7015c52e9.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3M-25"
-    ],
+    "part_numbers": ["Titan-3M-25"],
     "series": "Titan 3",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/ab4bc375-2042-4614-b0b2-3ef7015c52e9.json
+++ b/open-db/PrebuiltDesktop/ab4bc375-2042-4614-b0b2-3ef7015c52e9.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "ab4bc375-2042-4614-b0b2-3ef7015c52e9",
+  "metadata": {
+    "name": "Titan 3 - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3M-25"
+    ],
+    "series": "Titan 3",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3?variant=51950765998381"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131775",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3M-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950765998381",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/ab52e347-3860-4480-8552-04a08134b26d.json
+++ b/open-db/PrebuiltDesktop/ab52e347-3860-4480-8552-04a08134b26d.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "ab52e347-3860-4480-8552-04a08134b26d",
+  "metadata": {
+    "name": "Nova 5 - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5J-26"
+    ],
+    "series": "Nova 5",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5?variant=51950791196973"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568723",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5J-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791196973",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/ab52e347-3860-4480-8552-04a08134b26d.json
+++ b/open-db/PrebuiltDesktop/ab52e347-3860-4480-8552-04a08134b26d.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5J-26"
-    ],
+    "part_numbers": ["Nova-5J-26"],
     "series": "Nova 5",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/adb160ae-0c6e-4be0-8f33-2b3a743a9af2.json
+++ b/open-db/PrebuiltDesktop/adb160ae-0c6e-4be0-8f33-2b3a743a9af2.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 Bundle - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7L2-26"
-    ],
+    "part_numbers": ["Nova-7L2-26"],
     "series": "Nova 7 Bundle",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/adb160ae-0c6e-4be0-8f33-2b3a743a9af2.json
+++ b/open-db/PrebuiltDesktop/adb160ae-0c6e-4be0-8f33-2b3a743a9af2.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "adb160ae-0c6e-4be0-8f33-2b3a743a9af2",
+  "metadata": {
+    "name": "Nova 7 Bundle - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7L2-26"
+    ],
+    "series": "Nova 7 Bundle",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7-bundle?variant=51950790672685"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569140",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7L2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790672685",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/adf119b3-eaf3-4580-8c7a-f329d8732dc9.json
+++ b/open-db/PrebuiltDesktop/adf119b3-eaf3-4580-8c7a-f329d8732dc9.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "adf119b3-eaf3-4580-8c7a-f329d8732dc9",
+  "metadata": {
+    "name": "Nova 7 - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7J-26"
+    ],
+    "series": "Nova 7",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7?variant=51950791065901"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568822",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7J-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791065901",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/adf119b3-eaf3-4580-8c7a-f329d8732dc9.json
+++ b/open-db/PrebuiltDesktop/adf119b3-eaf3-4580-8c7a-f329d8732dc9.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7J-26"
-    ],
+    "part_numbers": ["Nova-7J-26"],
     "series": "Nova 7",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/ae1d1048-8208-4426-a2e0-2974c5d90737.json
+++ b/open-db/PrebuiltDesktop/ae1d1048-8208-4426-a2e0-2974c5d90737.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7J-25"
-    ],
+    "part_numbers": ["Apollo-7J-25"],
     "series": "Apollo 7",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/ae1d1048-8208-4426-a2e0-2974c5d90737.json
+++ b/open-db/PrebuiltDesktop/ae1d1048-8208-4426-a2e0-2974c5d90737.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "ae1d1048-8208-4426-a2e0-2974c5d90737",
+  "metadata": {
+    "name": "Apollo 7 - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7J-25"
+    ],
+    "series": "Apollo 7",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7?variant=51950793654573"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131645",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793654573",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/b1e6efee-d27f-48de-a230-0f69d106c295.json
+++ b/open-db/PrebuiltDesktop/b1e6efee-d27f-48de-a230-0f69d106c295.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "b1e6efee-d27f-48de-a230-0f69d106c295",
+  "metadata": {
+    "name": "Titan 7 - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7J-25"
+    ],
+    "series": "Titan 7",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7?variant=51950793326893"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131942",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793326893",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/b1e6efee-d27f-48de-a230-0f69d106c295.json
+++ b/open-db/PrebuiltDesktop/b1e6efee-d27f-48de-a230-0f69d106c295.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7J-25"
-    ],
+    "part_numbers": ["Titan-7J-25"],
     "series": "Titan 7",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/b4c02e8f-ef3c-4025-8f4b-85a71f41bd8f.json
+++ b/open-db/PrebuiltDesktop/b4c02e8f-ef3c-4025-8f4b-85a71f41bd8f.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 5 Bundle - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-5K2-26"
-    ],
+    "part_numbers": ["Nova-5K2-26"],
     "series": "Nova 5 Bundle",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/b4c02e8f-ef3c-4025-8f4b-85a71f41bd8f.json
+++ b/open-db/PrebuiltDesktop/b4c02e8f-ef3c-4025-8f4b-85a71f41bd8f.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "b4c02e8f-ef3c-4025-8f4b-85a71f41bd8f",
+  "metadata": {
+    "name": "Nova 5 Bundle - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-5K2-26"
+    ],
+    "series": "Nova 5 Bundle",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-5-bundle?variant=51950790770989"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569034",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-5K2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790770989",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/b4dcf8ca-9f14-4f6e-a432-c85af8c6c9f1.json
+++ b/open-db/PrebuiltDesktop/b4dcf8ca-9f14-4f6e-a432-c85af8c6c9f1.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 Bundle - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3J2-25"
-    ],
+    "part_numbers": ["Omega-3J2-25"],
     "series": "Omega 3 Bundle",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/b4dcf8ca-9f14-4f6e-a432-c85af8c6c9f1.json
+++ b/open-db/PrebuiltDesktop/b4dcf8ca-9f14-4f6e-a432-c85af8c6c9f1.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "b4dcf8ca-9f14-4f6e-a432-c85af8c6c9f1",
+  "metadata": {
+    "name": "Omega 3 Bundle - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3J2-25"
+    ],
+    "series": "Omega 3 Bundle",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3-bundle?variant=51950791786797"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134240",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791786797",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/b8ac2e54-955c-448a-8cdb-ee554c7d8fbc.json
+++ b/open-db/PrebuiltDesktop/b8ac2e54-955c-448a-8cdb-ee554c7d8fbc.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5N-25"
-    ],
+    "part_numbers": ["Apollo-5N-25"],
     "series": "Apollo 5",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/b8ac2e54-955c-448a-8cdb-ee554c7d8fbc.json
+++ b/open-db/PrebuiltDesktop/b8ac2e54-955c-448a-8cdb-ee554c7d8fbc.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "b8ac2e54-955c-448a-8cdb-ee554c7d8fbc",
+  "metadata": {
+    "name": "Apollo 5 - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5N-25"
+    ],
+    "series": "Apollo 5",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5?variant=51950794015021"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131584",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5N-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950794015021",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/bfe29d7e-1de6-4bbd-8cdf-ae14ae27052b.json
+++ b/open-db/PrebuiltDesktop/bfe29d7e-1de6-4bbd-8cdf-ae14ae27052b.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "bfe29d7e-1de6-4bbd-8cdf-ae14ae27052b",
+  "metadata": {
+    "name": "Omega 3 Bundle - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3L2-25"
+    ],
+    "series": "Omega 3 Bundle",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3-bundle?variant=51950791852333"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134264",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791852333",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/bfe29d7e-1de6-4bbd-8cdf-ae14ae27052b.json
+++ b/open-db/PrebuiltDesktop/bfe29d7e-1de6-4bbd-8cdf-ae14ae27052b.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 Bundle - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3L2-25"
-    ],
+    "part_numbers": ["Omega-3L2-25"],
     "series": "Omega 3 Bundle",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/c226e2d0-d4e0-4a87-8dea-ddaba556a099.json
+++ b/open-db/PrebuiltDesktop/c226e2d0-d4e0-4a87-8dea-ddaba556a099.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 Bundle - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3M2-26"
-    ],
+    "part_numbers": ["Nova-3M2-26"],
     "series": "Nova 3 Bundle",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/c226e2d0-d4e0-4a87-8dea-ddaba556a099.json
+++ b/open-db/PrebuiltDesktop/c226e2d0-d4e0-4a87-8dea-ddaba556a099.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "c226e2d0-d4e0-4a87-8dea-ddaba556a099",
+  "metadata": {
+    "name": "Nova 3 Bundle - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3M2-26"
+    ],
+    "series": "Nova 3 Bundle",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3-bundle?variant=51950790967597"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568952",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3M2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790967597",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/c38c11f2-1e67-4586-a09f-66fea840d392.json
+++ b/open-db/PrebuiltDesktop/c38c11f2-1e67-4586-a09f-66fea840d392.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "c38c11f2-1e67-4586-a09f-66fea840d392",
+  "metadata": {
+    "name": "Titan 3 Bundle - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3L2-25"
+    ],
+    "series": "Titan 3 Bundle",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3-bundle?variant=51950792376621"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133960",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792376621",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/c38c11f2-1e67-4586-a09f-66fea840d392.json
+++ b/open-db/PrebuiltDesktop/c38c11f2-1e67-4586-a09f-66fea840d392.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 Bundle - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3L2-25"
-    ],
+    "part_numbers": ["Titan-3L2-25"],
     "series": "Titan 3 Bundle",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/c7e890f2-4ab0-4ab4-91a4-9bc6528737ca.json
+++ b/open-db/PrebuiltDesktop/c7e890f2-4ab0-4ab4-91a4-9bc6528737ca.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "c7e890f2-4ab0-4ab4-91a4-9bc6528737ca",
+  "metadata": {
+    "name": "Nova 7 Bundle - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7K2-26"
+    ],
+    "series": "Nova 7 Bundle",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7-bundle?variant=51950790639917"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646569133",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7K2-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950790639917",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/c7e890f2-4ab0-4ab4-91a4-9bc6528737ca.json
+++ b/open-db/PrebuiltDesktop/c7e890f2-4ab0-4ab4-91a4-9bc6528737ca.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 Bundle - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7K2-26"
-    ],
+    "part_numbers": ["Nova-7K2-26"],
     "series": "Nova 7 Bundle",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/cc661de3-7e20-4991-ba93-29758066e444.json
+++ b/open-db/PrebuiltDesktop/cc661de3-7e20-4991-ba93-29758066e444.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "cc661de3-7e20-4991-ba93-29758066e444",
+  "metadata": {
+    "name": "Titan 7 Bundle - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7J2-25"
+    ],
+    "series": "Titan 7 Bundle",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7-bundle?variant=51950791950637"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134141",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7J2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791950637",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/cc661de3-7e20-4991-ba93-29758066e444.json
+++ b/open-db/PrebuiltDesktop/cc661de3-7e20-4991-ba93-29758066e444.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 Bundle - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7J2-25"
-    ],
+    "part_numbers": ["Titan-7J2-25"],
     "series": "Titan 7 Bundle",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/d0dc045f-4f83-4099-9336-71bb6d5ad6e5.json
+++ b/open-db/PrebuiltDesktop/d0dc045f-4f83-4099-9336-71bb6d5ad6e5.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 - 32GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5J-25"
-    ],
+    "part_numbers": ["Omega-5J-25"],
     "series": "Omega 5",
     "variant": "32GB DDR5 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/d0dc045f-4f83-4099-9336-71bb6d5ad6e5.json
+++ b/open-db/PrebuiltDesktop/d0dc045f-4f83-4099-9336-71bb6d5ad6e5.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d0dc045f-4f83-4099-9336-71bb6d5ad6e5",
+  "metadata": {
+    "name": "Omega 5 - 32GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5J-25"
+    ],
+    "series": "Omega 5",
+    "variant": "32GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5?variant=51950793031981"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132147",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5J-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793031981",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/d1755a48-bd1d-48bb-bee4-c30421dd7511.json
+++ b/open-db/PrebuiltDesktop/d1755a48-bd1d-48bb-bee4-c30421dd7511.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d1755a48-bd1d-48bb-bee4-c30421dd7511",
+  "metadata": {
+    "name": "Nova 3 - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3L-26"
+    ],
+    "series": "Nova 3",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3?variant=51950791393581"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "788362237110",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3L-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791393581",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/d1755a48-bd1d-48bb-bee4-c30421dd7511.json
+++ b/open-db/PrebuiltDesktop/d1755a48-bd1d-48bb-bee4-c30421dd7511.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3L-26"
-    ],
+    "part_numbers": ["Nova-3L-26"],
     "series": "Nova 3",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/d3d6c590-b019-498b-8ae2-74cdf35cd16b.json
+++ b/open-db/PrebuiltDesktop/d3d6c590-b019-498b-8ae2-74cdf35cd16b.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5L-25"
-    ],
+    "part_numbers": ["Omega-5L-25"],
     "series": "Omega 5",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/d3d6c590-b019-498b-8ae2-74cdf35cd16b.json
+++ b/open-db/PrebuiltDesktop/d3d6c590-b019-498b-8ae2-74cdf35cd16b.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d3d6c590-b019-498b-8ae2-74cdf35cd16b",
+  "metadata": {
+    "name": "Omega 5 - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5L-25"
+    ],
+    "series": "Omega 5",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5?variant=51950793097517"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132161",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793097517",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/d510514e-7c7a-4ea4-9713-284585384106.json
+++ b/open-db/PrebuiltDesktop/d510514e-7c7a-4ea4-9713-284585384106.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 7 - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-7I-25"
-    ],
+    "part_numbers": ["Titan-7I-25"],
     "series": "Titan 7",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/d510514e-7c7a-4ea4-9713-284585384106.json
+++ b/open-db/PrebuiltDesktop/d510514e-7c7a-4ea4-9713-284585384106.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d510514e-7c7a-4ea4-9713-284585384106",
+  "metadata": {
+    "name": "Titan 7 - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-7I-25"
+    ],
+    "series": "Titan 7",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-7?variant=51950793294125"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131935",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-7I-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793294125",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/d5bd92cc-35b4-47d3-bc07-720891330f04.json
+++ b/open-db/PrebuiltDesktop/d5bd92cc-35b4-47d3-bc07-720891330f04.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 Bundle - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3K2-25"
-    ],
+    "part_numbers": ["Omega-3K2-25"],
     "series": "Omega 3 Bundle",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/d5bd92cc-35b4-47d3-bc07-720891330f04.json
+++ b/open-db/PrebuiltDesktop/d5bd92cc-35b4-47d3-bc07-720891330f04.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d5bd92cc-35b4-47d3-bc07-720891330f04",
+  "metadata": {
+    "name": "Omega 3 Bundle - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3K2-25"
+    ],
+    "series": "Omega 3 Bundle",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3-bundle?variant=51950791819565"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134257",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791819565",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/d6e8c707-f10e-4a15-99e7-6e0a1f3a5fa8.json
+++ b/open-db/PrebuiltDesktop/d6e8c707-f10e-4a15-99e7-6e0a1f3a5fa8.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d6e8c707-f10e-4a15-99e7-6e0a1f3a5fa8",
+  "metadata": {
+    "name": "Apollo 7 - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7L-25"
+    ],
+    "series": "Apollo 7",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7?variant=51950793720109"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131669",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793720109",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/d6e8c707-f10e-4a15-99e7-6e0a1f3a5fa8.json
+++ b/open-db/PrebuiltDesktop/d6e8c707-f10e-4a15-99e7-6e0a1f3a5fa8.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7L-25"
-    ],
+    "part_numbers": ["Apollo-7L-25"],
     "series": "Apollo 7",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/d93c8b71-5f85-4e88-8e05-4e6025d0d3af.json
+++ b/open-db/PrebuiltDesktop/d93c8b71-5f85-4e88-8e05-4e6025d0d3af.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d93c8b71-5f85-4e88-8e05-4e6025d0d3af",
+  "metadata": {
+    "name": "Omega 5 Bundle - 32GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5L2-25"
+    ],
+    "series": "Omega 5 Bundle",
+    "variant": "32GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5-bundle?variant=51950791721261"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134363",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5L2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791721261",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/d93c8b71-5f85-4e88-8e05-4e6025d0d3af.json
+++ b/open-db/PrebuiltDesktop/d93c8b71-5f85-4e88-8e05-4e6025d0d3af.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 Bundle - 32GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5L2-25"
-    ],
+    "part_numbers": ["Omega-5L2-25"],
     "series": "Omega 5 Bundle",
     "variant": "32GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/db4b3402-3717-40c5-a0f6-0658e06d48ca.json
+++ b/open-db/PrebuiltDesktop/db4b3402-3717-40c5-a0f6-0658e06d48ca.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "db4b3402-3717-40c5-a0f6-0658e06d48ca",
+  "metadata": {
+    "name": "Nova 3 - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3M-26"
+    ],
+    "series": "Nova 3",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3?variant=51950791426349"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "788362237127",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3M-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791426349",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/db4b3402-3717-40c5-a0f6-0658e06d48ca.json
+++ b/open-db/PrebuiltDesktop/db4b3402-3717-40c5-a0f6-0658e06d48ca.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3M-26"
-    ],
+    "part_numbers": ["Nova-3M-26"],
     "series": "Nova 3",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/ddba5d52-3ba6-4a06-b3b0-2024ee64650e.json
+++ b/open-db/PrebuiltDesktop/ddba5d52-3ba6-4a06-b3b0-2024ee64650e.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "ddba5d52-3ba6-4a06-b3b0-2024ee64650e",
+  "metadata": {
+    "name": "Titan 3 - 32GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3L-25"
+    ],
+    "series": "Titan 3",
+    "variant": "32GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3?variant=51950765965613"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131768",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3L-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950765965613",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/ddba5d52-3ba6-4a06-b3b0-2024ee64650e.json
+++ b/open-db/PrebuiltDesktop/ddba5d52-3ba6-4a06-b3b0-2024ee64650e.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 - 32GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3L-25"
-    ],
+    "part_numbers": ["Titan-3L-25"],
     "series": "Titan 3",
     "variant": "32GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/e20dcde3-96dc-4ca5-825c-d6ef1e0cf416.json
+++ b/open-db/PrebuiltDesktop/e20dcde3-96dc-4ca5-825c-d6ef1e0cf416.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "e20dcde3-96dc-4ca5-825c-d6ef1e0cf416",
+  "metadata": {
+    "name": "Nova 7 - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-7K-26"
+    ],
+    "series": "Nova 7",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-7?variant=51950791098669"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "766646568839",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-7K-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791098669",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/e20dcde3-96dc-4ca5-825c-d6ef1e0cf416.json
+++ b/open-db/PrebuiltDesktop/e20dcde3-96dc-4ca5-825c-d6ef1e0cf416.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 7 - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-7K-26"
-    ],
+    "part_numbers": ["Nova-7K-26"],
     "series": "Nova 7",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/e2354c67-57cf-41a9-9566-2001615ea1a2.json
+++ b/open-db/PrebuiltDesktop/e2354c67-57cf-41a9-9566-2001615ea1a2.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "e2354c67-57cf-41a9-9566-2001615ea1a2",
+  "metadata": {
+    "name": "Nova 3 - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3K-26"
+    ],
+    "series": "Nova 3",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3?variant=51950791360813"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "788362237103",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3K-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791360813",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/e2354c67-57cf-41a9-9566-2001615ea1a2.json
+++ b/open-db/PrebuiltDesktop/e2354c67-57cf-41a9-9566-2001615ea1a2.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3K-26"
-    ],
+    "part_numbers": ["Nova-3K-26"],
     "series": "Nova 3",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/e4802d52-2310-4e07-bdcf-0db68a58af3f.json
+++ b/open-db/PrebuiltDesktop/e4802d52-2310-4e07-bdcf-0db68a58af3f.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Nova 3 - 32GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Nova-3J-26"
-    ],
+    "part_numbers": ["Nova-3J-26"],
     "series": "Nova 3",
     "variant": "32GB DDR4 + 512GB SSD",
     "releaseYear": 2026

--- a/open-db/PrebuiltDesktop/e4802d52-2310-4e07-bdcf-0db68a58af3f.json
+++ b/open-db/PrebuiltDesktop/e4802d52-2310-4e07-bdcf-0db68a58af3f.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "e4802d52-2310-4e07-bdcf-0db68a58af3f",
+  "metadata": {
+    "name": "Nova 3 - 32GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Nova-3J-26"
+    ],
+    "series": "Nova 3",
+    "variant": "32GB DDR4 + 512GB SSD",
+    "releaseYear": 2026
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/nova-3?variant=51950791328045"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "788362237097",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Nova-3J-26",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791328045",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/e7069955-75e6-4033-aaa3-5816b074158d.json
+++ b/open-db/PrebuiltDesktop/e7069955-75e6-4033-aaa3-5816b074158d.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 3 - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-3K-25"
-    ],
+    "part_numbers": ["Omega-3K-25"],
     "series": "Omega 3",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/e7069955-75e6-4033-aaa3-5816b074158d.json
+++ b/open-db/PrebuiltDesktop/e7069955-75e6-4033-aaa3-5816b074158d.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "e7069955-75e6-4033-aaa3-5816b074158d",
+  "metadata": {
+    "name": "Omega 3 - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-3K-25"
+    ],
+    "series": "Omega 3",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-3?variant=51950793195821"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132055",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-3K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793195821",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/ee928ce1-3870-471f-b08f-d6814a7c1e7e.json
+++ b/open-db/PrebuiltDesktop/ee928ce1-3870-471f-b08f-d6814a7c1e7e.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "ee928ce1-3870-471f-b08f-d6814a7c1e7e",
+  "metadata": {
+    "name": "Omega 7 - 16GB DDR5 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-7K-25"
+    ],
+    "series": "Omega 7",
+    "variant": "16GB DDR5 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-7?variant=51950792933677"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134132253",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-7K-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792933677",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/ee928ce1-3870-471f-b08f-d6814a7c1e7e.json
+++ b/open-db/PrebuiltDesktop/ee928ce1-3870-471f-b08f-d6814a7c1e7e.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 7 - 16GB DDR5 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-7K-25"
-    ],
+    "part_numbers": ["Omega-7K-25"],
     "series": "Omega 7",
     "variant": "16GB DDR5 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/ef19f98d-48b8-4bed-bdd6-341c0f61bcf2.json
+++ b/open-db/PrebuiltDesktop/ef19f98d-48b8-4bed-bdd6-341c0f61bcf2.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "ef19f98d-48b8-4bed-bdd6-341c0f61bcf2",
+  "metadata": {
+    "name": "Apollo 7 - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-7N-25"
+    ],
+    "series": "Apollo 7",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-7?variant=51950793785645"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131683",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-7N-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793785645",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/ef19f98d-48b8-4bed-bdd6-341c0f61bcf2.json
+++ b/open-db/PrebuiltDesktop/ef19f98d-48b8-4bed-bdd6-341c0f61bcf2.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 7 - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-7N-25"
-    ],
+    "part_numbers": ["Apollo-7N-25"],
     "series": "Apollo 7",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/f041c1fd-c113-428e-b054-c138ec43c448.json
+++ b/open-db/PrebuiltDesktop/f041c1fd-c113-428e-b054-c138ec43c448.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 Bundle - 32GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3N2-25"
-    ],
+    "part_numbers": ["Titan-3N2-25"],
     "series": "Titan 3 Bundle",
     "variant": "32GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/f041c1fd-c113-428e-b054-c138ec43c448.json
+++ b/open-db/PrebuiltDesktop/f041c1fd-c113-428e-b054-c138ec43c448.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "f041c1fd-c113-428e-b054-c138ec43c448",
+  "metadata": {
+    "name": "Titan 3 Bundle - 32GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3N2-25"
+    ],
+    "series": "Titan 3 Bundle",
+    "variant": "32GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3-bundle?variant=51950792442157"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133984",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3N2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792442157",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/f515ea9d-925e-446f-a5eb-fd769505e6d0.json
+++ b/open-db/PrebuiltDesktop/f515ea9d-925e-446f-a5eb-fd769505e6d0.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Titan 3 Bundle - 16GB DDR4 + 512GB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Titan-3I2-25"
-    ],
+    "part_numbers": ["Titan-3I2-25"],
     "series": "Titan 3 Bundle",
     "variant": "16GB DDR4 + 512GB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/f515ea9d-925e-446f-a5eb-fd769505e6d0.json
+++ b/open-db/PrebuiltDesktop/f515ea9d-925e-446f-a5eb-fd769505e6d0.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "f515ea9d-925e-446f-a5eb-fd769505e6d0",
+  "metadata": {
+    "name": "Titan 3 Bundle - 16GB DDR4 + 512GB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Titan-3I2-25"
+    ],
+    "series": "Titan 3 Bundle",
+    "variant": "16GB DDR4 + 512GB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/titan-3-bundle?variant=51950792278317"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133939",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Titan-3I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792278317",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/f7ad5ec6-764b-4fdf-9e18-38f285439d66.json
+++ b/open-db/PrebuiltDesktop/f7ad5ec6-764b-4fdf-9e18-38f285439d66.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "f7ad5ec6-764b-4fdf-9e18-38f285439d66",
+  "metadata": {
+    "name": "Apollo 5 - 16GB DDR4 + 2TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5M-25"
+    ],
+    "series": "Apollo 5",
+    "variant": "16GB DDR4 + 2TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5?variant=51950793982253"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134131577",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5M-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950793982253",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/f7ad5ec6-764b-4fdf-9e18-38f285439d66.json
+++ b/open-db/PrebuiltDesktop/f7ad5ec6-764b-4fdf-9e18-38f285439d66.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 - 16GB DDR4 + 2TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5M-25"
-    ],
+    "part_numbers": ["Apollo-5M-25"],
     "series": "Apollo 5",
     "variant": "16GB DDR4 + 2TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/fabe1082-1315-4bac-8f64-a22e1a106ad3.json
+++ b/open-db/PrebuiltDesktop/fabe1082-1315-4bac-8f64-a22e1a106ad3.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "fabe1082-1315-4bac-8f64-a22e1a106ad3",
+  "metadata": {
+    "name": "Apollo 5 Bundle - 16GB DDR4 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Apollo-5K2-25"
+    ],
+    "series": "Apollo 5 Bundle",
+    "variant": "16GB DDR4 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/apollo-5-bundle?variant=51950792737069"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134133755",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Apollo-5K2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950792737069",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/fabe1082-1315-4bac-8f64-a22e1a106ad3.json
+++ b/open-db/PrebuiltDesktop/fabe1082-1315-4bac-8f64-a22e1a106ad3.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Apollo 5 Bundle - 16GB DDR4 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Apollo-5K2-25"
-    ],
+    "part_numbers": ["Apollo-5K2-25"],
     "series": "Apollo 5 Bundle",
     "variant": "16GB DDR4 + 1TB SSD",
     "releaseYear": 2025

--- a/open-db/PrebuiltDesktop/fe29f29c-5e8a-4e61-842c-a25e65608cd5.json
+++ b/open-db/PrebuiltDesktop/fe29f29c-5e8a-4e61-842c-a25e65608cd5.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "fe29f29c-5e8a-4e61-842c-a25e65608cd5",
+  "metadata": {
+    "name": "Omega 5 Bundle - 16GB DDR5 + 1TB SSD",
+    "manufacturer": "Gigatech Gaming",
+    "part_numbers": [
+      "Omega-5I2-25"
+    ],
+    "series": "Omega 5 Bundle",
+    "variant": "16GB DDR5 + 1TB SSD",
+    "releaseYear": 2025
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://gigatechgaming.com/products/omega-5-bundle?variant=51950791622957"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "gtin",
+        "value": "644134134332",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "Omega-5I2-25",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "gigatech-gaming",
+        "channel": "us",
+        "source_product_id": "51950791622957",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/PrebuiltDesktop/fe29f29c-5e8a-4e61-842c-a25e65608cd5.json
+++ b/open-db/PrebuiltDesktop/fe29f29c-5e8a-4e61-842c-a25e65608cd5.json
@@ -3,9 +3,7 @@
   "metadata": {
     "name": "Omega 5 Bundle - 16GB DDR5 + 1TB SSD",
     "manufacturer": "Gigatech Gaming",
-    "part_numbers": [
-      "Omega-5I2-25"
-    ],
+    "part_numbers": ["Omega-5I2-25"],
     "series": "Omega 5 Bundle",
     "variant": "16GB DDR5 + 1TB SSD",
     "releaseYear": 2025


### PR DESCRIPTION
## Summary

- add all 104 current Gigatech Gaming variants from AWIN feed F3648 as distinct `PrebuiltDesktop` parts
- preserve Gigatech's 22 product families as `series` and each RAM/storage configuration as its own `variant`
- add the exact manufacturer MPN, GTIN, direct variant URL, release year, and verified `gigatech-gaming/us` retailer listing to every part
- keep bundle and non-bundle products separate because they are distinct products with distinct MPNs, GTINs, variant IDs, prices, and included hardware

## Duplicate audit

- scanned all 96 `PrebuiltDesktop` documents on current upstream `main`
- checked production `prebuilt_desktops`, `temp_prebuilt_desktops`, and `community_prebuilt_desktops` using the read-only database connection
- found zero existing matches by normalized name, MPN, GTIN, Gigatech source product ID, or Gigatech retailer source
- confirmed 104 unique OpenDB UUIDs, names, MPNs, GTINs, and source product IDs in this PR

## Image coverage

- cross-checked every AWIN row against the exact Shopify variant ID and product handle
- all 104 variants have at least one Shopify product image; variants have one or two images
- the catalog resolves to 15 unique CDN image URLs, and all 15 returned successfully during validation
- OpenDB's current `PrebuiltDesktop` schema does not support `image` or `multi_image`, so these documents retain the exact manufacturer variant URL instead of adding unsupported fields
- after OpenDB imports these new parts, their verified Shopify image map must be applied to MongoDB's `image` / `multi_image` fields as a separate post-import step

## Validation

- current `schemas/PrebuiltDesktop.schema.json`: **104 passed, 0 failed**
- feed-to-document semantic verification: **104/104 matched, 0 missing, 0 errors**
- AWIN ↔ Shopify cross-checks: exact variant ID, MPN/SKU, title, product handle, direct variant URL, GTIN check digit, and feed image
- image reachability: **15/15 unique CDN URLs passed**
- `git diff --check`

## System diagram

Not applicable: this PR adds catalog data and introduces no new system behavior.

## AI-assisted development disclosure

- Model(s): GPT-5 Codex
- Agent harness(es): Codex desktop
- Initial user prompt: Add every Gigatech Gaming feed product to OpenDB, preserve images, and ensure there are no duplicates. The credential-bearing feed URL was redacted.
- Sources consulted: user-supplied AWIN F3648 feed; `https://gigatechgaming.com/products.json`; current OpenDB `PrebuiltDesktop` schema and variant guidance; read-only production duplicate audit
