### PR TITLE
Reopen Xiaomi catalog additions from #351

### DIFF
--- a/open-db/Headphones/0892d384-88db-463d-a863-d9cde02166df.json
+++ b/open-db/Headphones/0892d384-88db-463d-a863-d9cde02166df.json
@@ -1,32 +1,31 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "0892d384-88db-463d-a863-d9cde02166df",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "REDMI Buds 4 Active Black",
     "manufacturer": "Xiaomi",
+    "series": "Buds 4 Active",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
     "variant": "Black"
   },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-4-active/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812712733",
         "region": "all"
       }
     ],
     "retailer_listings": [
       {
         "source": "xiaomi",
-        "channel": "pl",
-        "source_product_id": "57944",
+        "channel": "it",
+        "source_product_id": "45255",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Headphones/0a2708ed-88e4-4746-b083-0d809bbb783f.json
+++ b/open-db/Headphones/0a2708ed-88e4-4746-b083-0d809bbb783f.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "0a2708ed-88e4-4746-b083-0d809bbb783f",
+  "metadata": {
+    "name": "Xiaomi Buds 5 Pro Translucent Black (Wi-Fi)",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 5 Pro",
+    "part_numbers": [],
+    "variant": "Translucent Black (Wi-Fi)"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-5-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812779491",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "61096",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "61096",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "61096",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "61096",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/11e55ec0-e62e-411a-9443-462567a3effb.json
+++ b/open-db/Headphones/11e55ec0-e62e-411a-9443-462567a3effb.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "11e55ec0-e62e-411a-9443-462567a3effb",
+  "metadata": {
+    "name": "REDMI Buds 8 Lite White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Lite",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554471880",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "71619",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "71619",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "71619",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "71619",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/145817c0-3f6c-409d-bd93-47e33c5e9099.json
+++ b/open-db/Headphones/145817c0-3f6c-409d-bd93-47e33c5e9099.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "145817c0-3f6c-409d-bd93-47e33c5e9099",
+  "metadata": {
+    "name": "REDMI Buds 5 Pro Midnight Black",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 5 Pro",
+    "part_numbers": [],
+    "variant": "Midnight Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-5-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812746165",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "50138",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "50138",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/1498ea35-aedf-4dc2-aa6a-f3c455391ca7.json
+++ b/open-db/Headphones/1498ea35-aedf-4dc2-aa6a-f3c455391ca7.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "1498ea35-aedf-4dc2-aa6a-f3c455391ca7",
+  "metadata": {
+    "name": "REDMI Buds 8 Active White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Active",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554464240",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70468",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70468",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70468",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70468",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/14a47009-0fa1-450b-80cc-55c3e91b1012.json
+++ b/open-db/Headphones/14a47009-0fa1-450b-80cc-55c3e91b1012.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "14a47009-0fa1-450b-80cc-55c3e91b1012",
+  "metadata": {
+    "name": "REDMI Buds 6 Pro Lavender Purple",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Pro",
+    "part_numbers": [],
+    "variant": "Lavender Purple"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812765302",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59568",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59568",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59568",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "59568",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/152a81f3-c0f7-4926-bb5f-5724986023c3.json
+++ b/open-db/Headphones/152a81f3-c0f7-4926-bb5f-5724986023c3.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "152a81f3-c0f7-4926-bb5f-5724986023c3",
+  "metadata": {
+    "name": "Xiaomi Buds 6 Nebula Purple",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 6",
+    "part_numbers": [],
+    "variant": "Nebula Purple"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-6/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554470692",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "79113",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "79113",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "79113",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "79113",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/175de2b4-d40a-42f3-95fd-c585badaa3b5.json
+++ b/open-db/Headphones/175de2b4-d40a-42f3-95fd-c585badaa3b5.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "175de2b4-d40a-42f3-95fd-c585badaa3b5",
+  "metadata": {
+    "name": "REDMI Buds 6 Play White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Play",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812791271",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57676",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57676",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57676",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57676",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/1d75fee9-782b-46b8-9372-55f2f1b492d7.json
+++ b/open-db/Headphones/1d75fee9-782b-46b8-9372-55f2f1b492d7.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "1d75fee9-782b-46b8-9372-55f2f1b492d7",
+  "metadata": {
+    "name": "REDMI Buds 8 Pro Cloud White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Pro",
+    "part_numbers": [],
+    "variant": "Cloud White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554458126",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "69544",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "69544",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "69544",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "69544",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/2925765f-57b1-4833-967b-dca91380bdea.json
+++ b/open-db/Headphones/2925765f-57b1-4833-967b-dca91380bdea.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "2925765f-57b1-4833-967b-dca91380bdea",
+  "metadata": {
+    "name": "Xiaomi Buds 5 Titan Gray",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 5",
+    "part_numbers": [],
+    "variant": "Titan Gray"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-5/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812768518",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "54397",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "54397",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "54397",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "54397",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/40086254-0628-4cd5-aa86-69384fe46b80.json
+++ b/open-db/Headphones/40086254-0628-4cd5-aa86-69384fe46b80.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "40086254-0628-4cd5-aa86-69384fe46b80",
+  "metadata": {
+    "name": "Xiaomi Buds 5 Ceramic White",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 5",
+    "part_numbers": [],
+    "variant": "Ceramic White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-5/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812768464",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "54398",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "54398",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "54398",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "54398",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/41b0a22b-46fc-4771-9d27-99b1ddb783e8.json
+++ b/open-db/Headphones/41b0a22b-46fc-4771-9d27-99b1ddb783e8.json
@@ -1,0 +1,48 @@
+{
+  "opendb_id": "41b0a22b-46fc-4771-9d27-99b1ddb783e8",
+  "metadata": {
+    "name": "Xiaomi Type-C Earphones White",
+    "manufacturer": "Xiaomi",
+    "series": "Type-C Earphones",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "In-Ear",
+  "connection_types": ["USB-C"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-type-c-earphones/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812793152",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57983",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57983",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57983",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/5305a85c-93e6-4e19-80ac-a456ba87b4cc.json
+++ b/open-db/Headphones/5305a85c-93e6-4e19-80ac-a456ba87b4cc.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "5305a85c-93e6-4e19-80ac-a456ba87b4cc",
+  "metadata": {
+    "name": "REDMI Buds 6 Active White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Active",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812777527",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "55691",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "55691",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "55691",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "55691",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/5752ea5f-fd3e-43cf-890c-7ea15fa587e1.json
+++ b/open-db/Headphones/5752ea5f-fd3e-43cf-890c-7ea15fa587e1.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "5752ea5f-fd3e-43cf-890c-7ea15fa587e1",
+  "metadata": {
+    "name": "Xiaomi Buds 5 Pro Ceramic White",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 5 Pro",
+    "part_numbers": [],
+    "variant": "Ceramic White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-5-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812772256",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "61091",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "61091",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "61091",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "61091",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/57b1d005-d6b6-46fe-bd24-2e470cb9b329.json
+++ b/open-db/Headphones/57b1d005-d6b6-46fe-bd24-2e470cb9b329.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "57b1d005-d6b6-46fe-bd24-2e470cb9b329",
+  "metadata": {
+    "name": "REDMI Buds 6 Cloud White",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 6",
+    "part_numbers": [],
+    "variant": "Cloud White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812704653",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59306",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59306",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59306",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "59306",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/5816c3c4-7487-4cfc-9872-c4f4b8cd1fc6.json
+++ b/open-db/Headphones/5816c3c4-7487-4cfc-9872-c4f4b8cd1fc6.json
@@ -1,0 +1,48 @@
+{
+  "opendb_id": "5816c3c4-7487-4cfc-9872-c4f4b8cd1fc6",
+  "metadata": {
+    "name": "Xiaomi Type-C Earphones Black",
+    "manufacturer": "Xiaomi",
+    "series": "Type-C Earphones",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "In-Ear",
+  "connection_types": ["USB-C"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-type-c-earphones/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812793145",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57982",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57982",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57982",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/58cf08d0-687b-4d70-a1b2-5e440695f542.json
+++ b/open-db/Headphones/58cf08d0-687b-4d70-a1b2-5e440695f542.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "58cf08d0-687b-4d70-a1b2-5e440695f542",
+  "metadata": {
+    "name": "REDMI Buds 8 Active Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Active",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554464233",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70467",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70467",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70467",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70467",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/671a0f63-878c-4e9e-b5a6-892e21e34819.json
+++ b/open-db/Headphones/671a0f63-878c-4e9e-b5a6-892e21e34819.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "671a0f63-878c-4e9e-b5a6-892e21e34819",
+  "metadata": {
+    "name": "REDMI Buds 6 Active Pink",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Active",
+    "part_numbers": [],
+    "variant": "Pink"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812777565",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "55695",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "55695",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "55695",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "55695",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/6779ebf6-a3a1-4689-b9a3-b0a80c355e05.json
+++ b/open-db/Headphones/6779ebf6-a3a1-4689-b9a3-b0a80c355e05.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "6779ebf6-a3a1-4689-b9a3-b0a80c355e05",
+  "metadata": {
+    "name": "Xiaomi Buds 6 Ceramic White",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 6",
+    "part_numbers": [],
+    "variant": "Ceramic White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-6/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554471842",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "71611",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "71611",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "71611",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "71611",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/6ccd15de-0678-4aa9-86b0-ab5c029d7cb4.json
+++ b/open-db/Headphones/6ccd15de-0678-4aa9-86b0-ab5c029d7cb4.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "6ccd15de-0678-4aa9-86b0-ab5c029d7cb4",
+  "metadata": {
+    "name": "REDMI Buds 8 Green",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8",
+    "part_numbers": [],
+    "variant": "Green"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554486556",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "73461",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "73461",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "73461",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "73461",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/76667be0-b829-454b-ad52-041e82796849.json
+++ b/open-db/Headphones/76667be0-b829-454b-ad52-041e82796849.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "76667be0-b829-454b-ad52-041e82796849",
+  "metadata": {
+    "name": "REDMI Buds 8 White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554486532",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "73459",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "73459",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "73459",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "73459",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/785619f8-1d6c-4886-82c1-c57c54ac6e88.json
+++ b/open-db/Headphones/785619f8-1d6c-4886-82c1-c57c54ac6e88.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "785619f8-1d6c-4886-82c1-c57c54ac6e88",
+  "metadata": {
+    "name": "REDMI Buds 5 Pro Moonlight White",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 5 Pro",
+    "part_numbers": [],
+    "variant": "Moonlight White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-5-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812746110",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "50140",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "50140",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/7da8c67d-44cf-488b-8056-f394c7aafee5.json
+++ b/open-db/Headphones/7da8c67d-44cf-488b-8056-f394c7aafee5.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "7da8c67d-44cf-488b-8056-f394c7aafee5",
+  "metadata": {
+    "name": "REDMI Buds 6 Pro Glacier White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Pro",
+    "part_numbers": [],
+    "variant": "Glacier White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812743577",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59561",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59561",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59561",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "59561",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/7f65b02a-ab06-4458-9521-753fca993a46.json
+++ b/open-db/Headphones/7f65b02a-ab06-4458-9521-753fca993a46.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "7f65b02a-ab06-4458-9521-753fca993a46",
+  "metadata": {
+    "name": "Xiaomi Buds 6 Titan Grey",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 6",
+    "part_numbers": [],
+    "variant": "Titan Grey"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-6/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554471859",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "71612",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "71612",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "71612",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "71612",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/811e884b-5fe1-4711-a7ce-b858aa565fea.json
+++ b/open-db/Headphones/811e884b-5fe1-4711-a7ce-b858aa565fea.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "811e884b-5fe1-4711-a7ce-b858aa565fea",
+  "metadata": {
+    "name": "REDMI Buds 6 Lite Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Lite",
+    "part_numbers": [],
+    "variant": "Blue"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812787793",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57186",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57186",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/87589368-35f5-468b-a354-2deab2865b33.json
+++ b/open-db/Headphones/87589368-35f5-468b-a354-2deab2865b33.json
@@ -1,0 +1,48 @@
+{
+  "opendb_id": "87589368-35f5-468b-a354-2deab2865b33",
+  "metadata": {
+    "name": "REDMI Buds 5 Pro Aurora Purple",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 5 Pro",
+    "part_numbers": [],
+    "variant": "Aurora Purple"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-5-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812752067",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "50977",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "50977",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "50977",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/8b1ef344-88bc-41fa-a16e-e5dec59c28d9.json
+++ b/open-db/Headphones/8b1ef344-88bc-41fa-a16e-e5dec59c28d9.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "8b1ef344-88bc-41fa-a16e-e5dec59c28d9",
+  "metadata": {
+    "name": "REDMI Buds 8 Active Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Active",
+    "part_numbers": [],
+    "variant": "Blue"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554464196",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70463",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70463",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70463",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70463",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/8e1e7efc-0bdf-49d9-8086-efea715ad2b1.json
+++ b/open-db/Headphones/8e1e7efc-0bdf-49d9-8086-efea715ad2b1.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "8e1e7efc-0bdf-49d9-8086-efea715ad2b1",
+  "metadata": {
+    "name": "REDMI Buds 6 Active Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Active",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812777572",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "55696",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "55696",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "55696",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "55696",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/8e8d885b-b2a0-4e9b-bc50-b7a33eaa8860.json
+++ b/open-db/Headphones/8e8d885b-b2a0-4e9b-bc50-b7a33eaa8860.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "8e8d885b-b2a0-4e9b-bc50-b7a33eaa8860",
+  "metadata": {
+    "name": "Mi In-Ear Headphones Basic Black",
+    "manufacturer": "Xiaomi",
+    "series": "In-Ear Headphones Basic",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "In-Ear",
+  "connection_types": ["Wired 3.5mm"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/headphones_basic2/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6970244522184",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "14273",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "14273",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "14273",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "14273",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/90915708-d116-488e-a42a-776faf5d8930.json
+++ b/open-db/Headphones/90915708-d116-488e-a42a-776faf5d8930.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "90915708-d116-488e-a42a-776faf5d8930",
+  "metadata": {
+    "name": "REDMI Buds 6 Play Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Play",
+    "part_numbers": [],
+    "variant": "Blue"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812737071",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59438",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59438",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59438",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "59438",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/944bceeb-b115-4af7-9172-1d967b0ccf65.json
+++ b/open-db/Headphones/944bceeb-b115-4af7-9172-1d967b0ccf65.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "944bceeb-b115-4af7-9172-1d967b0ccf65",
+  "metadata": {
+    "name": "REDMI Buds 6 Play Pink",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Play",
+    "part_numbers": [],
+    "variant": "Pink"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812791295",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57678",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57678",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57678",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57678",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/96910d88-236d-4adc-b2b9-ff1434bd590c.json
+++ b/open-db/Headphones/96910d88-236d-4adc-b2b9-ff1434bd590c.json
@@ -1,32 +1,31 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "96910d88-236d-4adc-b2b9-ff1434bd590c",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "REDMI Buds 5 Black",
     "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 5",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
     "variant": "Black"
   },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-5/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812744321",
         "region": "all"
       }
     ],
     "retailer_listings": [
       {
         "source": "xiaomi",
-        "channel": "pl",
-        "source_product_id": "57944",
+        "channel": "it",
+        "source_product_id": "49902",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Headphones/970380c6-d927-4d85-9563-dda5f1f80be9.json
+++ b/open-db/Headphones/970380c6-d927-4d85-9563-dda5f1f80be9.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "970380c6-d927-4d85-9563-dda5f1f80be9",
+  "metadata": {
+    "name": "REDMI Buds 6 Lite White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Lite",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812787847",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57181",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57181",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/9d3486f2-fc79-4d76-a0e0-7f1826b1ce1f.json
+++ b/open-db/Headphones/9d3486f2-fc79-4d76-a0e0-7f1826b1ce1f.json
@@ -1,0 +1,34 @@
+{
+  "opendb_id": "9d3486f2-fc79-4d76-a0e0-7f1826b1ce1f",
+  "metadata": {
+    "name": "REDMI Buds 4 Active White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 4 Active",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-4-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812761984",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "53355",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/a17d313d-2620-41eb-90a0-1356b46267a8.json
+++ b/open-db/Headphones/a17d313d-2620-41eb-90a0-1356b46267a8.json
@@ -1,32 +1,31 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "a17d313d-2620-41eb-90a0-1356b46267a8",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "REDMI Buds 4 Lite Black",
     "manufacturer": "Xiaomi",
+    "series": "Buds 4 Lite",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
     "variant": "Black"
   },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-4-lite/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812721032",
         "region": "all"
       }
     ],
     "retailer_listings": [
       {
         "source": "xiaomi",
-        "channel": "pl",
-        "source_product_id": "57944",
+        "channel": "it",
+        "source_product_id": "46432",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Headphones/a372eaf5-7559-4192-a001-427f9997263c.json
+++ b/open-db/Headphones/a372eaf5-7559-4192-a001-427f9997263c.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "a372eaf5-7559-4192-a001-427f9997263c",
+  "metadata": {
+    "name": "REDMI Headphones Neo Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Headphones Neo",
+    "part_numbers": [],
+    "variant": "Blue"
+  },
+  "connection_types": ["Bluetooth", "USB-C"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-headphones-neo/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554487478",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "73671",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "73671",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/af73121b-8146-4d7b-a06e-0e4b82ac9c4b.json
+++ b/open-db/Headphones/af73121b-8146-4d7b-a06e-0e4b82ac9c4b.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "af73121b-8146-4d7b-a06e-0e4b82ac9c4b",
+  "metadata": {
+    "name": "REDMI Buds 8 Pro Glacier Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Pro",
+    "part_numbers": [],
+    "variant": "Glacier Blue"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554458157",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "69547",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "69547",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "69547",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "69547",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/b0b4386b-08af-4576-bf3a-65cb08de16b8.json
+++ b/open-db/Headphones/b0b4386b-08af-4576-bf3a-65cb08de16b8.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "b0b4386b-08af-4576-bf3a-65cb08de16b8",
+  "metadata": {
+    "name": "REDMI Buds 8 Lite Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Lite",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554471897",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "71620",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "71620",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "71620",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "71620",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/be2196f4-7284-41bc-994c-938cabf18e36.json
+++ b/open-db/Headphones/be2196f4-7284-41bc-994c-938cabf18e36.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "be2196f4-7284-41bc-994c-938cabf18e36",
+  "metadata": {
+    "name": "REDMI Buds 5 Sky Blue",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 5",
+    "part_numbers": [],
+    "variant": "Sky Blue"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-5/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812744369",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "49906",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "49906",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/c09abd42-d8ec-4cd7-8da6-031c7c0d80d7.json
+++ b/open-db/Headphones/c09abd42-d8ec-4cd7-8da6-031c7c0d80d7.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "c09abd42-d8ec-4cd7-8da6-031c7c0d80d7",
+  "metadata": {
+    "name": "REDMI Buds 8 Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554486518",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "73457",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "73457",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "73457",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "73457",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/c2c753af-d8ce-4de3-8769-cbb5c8e987c7.json
+++ b/open-db/Headphones/c2c753af-d8ce-4de3-8769-cbb5c8e987c7.json
@@ -1,0 +1,34 @@
+{
+  "opendb_id": "c2c753af-d8ce-4de3-8769-cbb5c8e987c7",
+  "metadata": {
+    "name": "REDMI Buds 3 Lite White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 3 Lite",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-3-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177757020",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "36104",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/c5e28012-e69d-4fcd-a535-edf59d91a695.json
+++ b/open-db/Headphones/c5e28012-e69d-4fcd-a535-edf59d91a695.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "c5e28012-e69d-4fcd-a535-edf59d91a695",
+  "metadata": {
+    "name": "Xiaomi Buds 6 Graphite Black",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 6",
+    "part_numbers": [],
+    "variant": "Graphite Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-6/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554471811",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "71608",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "71608",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "71608",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "71608",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/c79bdbb7-03e2-4a88-a360-32f6c3327f4c.json
+++ b/open-db/Headphones/c79bdbb7-03e2-4a88-a360-32f6c3327f4c.json
@@ -1,24 +1,23 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "c79bdbb7-03e2-4a88-a360-32f6c3327f4c",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Buds 3 Star Wars Edition White",
     "manufacturer": "Xiaomi",
+    "series": "Buds 3 Star Wars Edition",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "White"
   },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-buds-3-star-wars-edition/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812713402",
         "region": "all"
       }
     ],
@@ -26,7 +25,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "45429",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Headphones/c985364e-212d-43df-926b-6230474cc9f9.json
+++ b/open-db/Headphones/c985364e-212d-43df-926b-6230474cc9f9.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "c985364e-212d-43df-926b-6230474cc9f9",
+  "metadata": {
+    "name": "REDMI Buds 5 White",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 5",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-5/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812744338",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "49903",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "49903",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/cf17db9c-4bab-4a37-a9da-dec6c4c8065d.json
+++ b/open-db/Headphones/cf17db9c-4bab-4a37-a9da-dec6c4c8065d.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "cf17db9c-4bab-4a37-a9da-dec6c4c8065d",
+  "metadata": {
+    "name": "Xiaomi Buds 5 Graphite Black",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 5",
+    "part_numbers": [],
+    "variant": "Graphite Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-5/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812768471",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "54399",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "54399",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "54399",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "54399",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/d0591304-86ee-4f5a-83d0-ae7a7ddecd91.json
+++ b/open-db/Headphones/d0591304-86ee-4f5a-83d0-ae7a7ddecd91.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "d0591304-86ee-4f5a-83d0-ae7a7ddecd91",
+  "metadata": {
+    "name": "REDMI Headphones Neo Black",
+    "manufacturer": "Xiaomi",
+    "series": "Headphones Neo",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "connection_types": ["Bluetooth", "USB-C"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-headphones-neo/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554487461",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "73670",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "73670",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/d37b5453-d252-44e9-a1e3-eb1a3ef750b8.json
+++ b/open-db/Headphones/d37b5453-d252-44e9-a1e3-eb1a3ef750b8.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "d37b5453-d252-44e9-a1e3-eb1a3ef750b8",
+  "metadata": {
+    "name": "REDMI Buds 6 Coral Green",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 6",
+    "part_numbers": [],
+    "variant": "Coral Green"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812799734",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59301",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59301",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59301",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "59301",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/d5bd2af8-4392-4e5c-8d28-8dec721987b4.json
+++ b/open-db/Headphones/d5bd2af8-4392-4e5c-8d28-8dec721987b4.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "d5bd2af8-4392-4e5c-8d28-8dec721987b4",
+  "metadata": {
+    "name": "Mi In-Ear Headphones Basic Silver",
+    "manufacturer": "Xiaomi",
+    "series": "In-Ear Headphones Basic",
+    "part_numbers": [],
+    "variant": "Silver"
+  },
+  "ear_cup_type": "In-Ear",
+  "connection_types": ["Wired 3.5mm"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/headphones_basic2/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6970244522191",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "14274",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "14274",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "14274",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "14274",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/d8d4d5e5-f4b2-47d8-b8a7-86ef8f2d4447.json
+++ b/open-db/Headphones/d8d4d5e5-f4b2-47d8-b8a7-86ef8f2d4447.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "d8d4d5e5-f4b2-47d8-b8a7-86ef8f2d4447",
+  "metadata": {
+    "name": "REDMI Buds 8 Pro Obsidian Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Pro",
+    "part_numbers": [],
+    "variant": "Obsidian Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554458171",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "69549",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "69549",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "69549",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "69549",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/dde600a8-f0dc-4b48-835c-baafbe9a576a.json
+++ b/open-db/Headphones/dde600a8-f0dc-4b48-835c-baafbe9a576a.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "dde600a8-f0dc-4b48-835c-baafbe9a576a",
+  "metadata": {
+    "name": "REDMI Buds 6 Pro Space Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Pro",
+    "part_numbers": [],
+    "variant": "Space Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812777756",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59558",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59558",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59558",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "59558",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/df8231f4-19a1-41d4-94e2-03d747be401d.json
+++ b/open-db/Headphones/df8231f4-19a1-41d4-94e2-03d747be401d.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "df8231f4-19a1-41d4-94e2-03d747be401d",
+  "metadata": {
+    "name": "REDMI Buds 4 Lite White",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 4 Lite",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-4-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812707968",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "44483",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "44483",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/dfeb5af3-2f7e-4d0b-ac31-e06d68dd35e9.json
+++ b/open-db/Headphones/dfeb5af3-2f7e-4d0b-ac31-e06d68dd35e9.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "dfeb5af3-2f7e-4d0b-ac31-e06d68dd35e9",
+  "metadata": {
+    "name": "REDMI Buds 6 Active Transparent Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Active",
+    "part_numbers": [],
+    "variant": "Transparent Blue"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-active/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812777558",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "55694",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "55694",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "55694",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "55694",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/e0704d67-b5fe-481d-8e4c-e1c52c731595.json
+++ b/open-db/Headphones/e0704d67-b5fe-481d-8e4c-e1c52c731595.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "e0704d67-b5fe-481d-8e4c-e1c52c731595",
+  "metadata": {
+    "name": "Xiaomi Buds 5 Pro Titan Gray",
+    "manufacturer": "Xiaomi",
+    "series": "Xiaomi Buds 5 Pro",
+    "part_numbers": [],
+    "variant": "Titan Gray"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-buds-5-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812772232",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "61089",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "61089",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "61089",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "61089",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/e2f865c1-20c4-48ab-a72c-5d15342da834.json
+++ b/open-db/Headphones/e2f865c1-20c4-48ab-a72c-5d15342da834.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "e2f865c1-20c4-48ab-a72c-5d15342da834",
+  "metadata": {
+    "name": "REDMI Buds 6 Night Black",
+    "manufacturer": "Xiaomi",
+    "series": "REDMI Buds 6",
+    "part_numbers": [],
+    "variant": "Night Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812704660",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59307",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59307",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59307",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "59307",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/eca1afc9-c221-4dd5-8b8f-3f4d1ba338e8.json
+++ b/open-db/Headphones/eca1afc9-c221-4dd5-8b8f-3f4d1ba338e8.json
@@ -1,24 +1,23 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "eca1afc9-c221-4dd5-8b8f-3f4d1ba338e8",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Buds 3 White",
     "manufacturer": "Xiaomi",
+    "series": "Buds 3",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "White"
   },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-buds-3/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6934177758140",
         "region": "all"
       }
     ],
@@ -26,7 +25,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "36265",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Headphones/ed1cc139-ef1b-4905-b7a0-9b3ce060aeaa.json
+++ b/open-db/Headphones/ed1cc139-ef1b-4905-b7a0-9b3ce060aeaa.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "ed1cc139-ef1b-4905-b7a0-9b3ce060aeaa",
+  "metadata": {
+    "name": "REDMI Headphones Neo White",
+    "manufacturer": "Xiaomi",
+    "series": "Headphones Neo",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "connection_types": ["Bluetooth", "USB-C"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-headphones-neo/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554487430",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "73667",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "73667",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/f6240aac-087f-4c67-8a8e-1a1f1eaa9eb7.json
+++ b/open-db/Headphones/f6240aac-087f-4c67-8a8e-1a1f1eaa9eb7.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "f6240aac-087f-4c67-8a8e-1a1f1eaa9eb7",
+  "metadata": {
+    "name": "REDMI Buds 6 Play Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Play",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812791240",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57679",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57679",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57679",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57679",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/f6a40c6e-98f3-4fc9-8350-2b1022685dbd.json
+++ b/open-db/Headphones/f6a40c6e-98f3-4fc9-8350-2b1022685dbd.json
@@ -1,0 +1,41 @@
+{
+  "opendb_id": "f6a40c6e-98f3-4fc9-8350-2b1022685dbd",
+  "metadata": {
+    "name": "REDMI Buds 6 Lite Black",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 6 Lite",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-6-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812787823",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57179",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57179",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Headphones/f6f51e26-3ec7-40f2-a43b-13aa1f28f737.json
+++ b/open-db/Headphones/f6f51e26-3ec7-40f2-a43b-13aa1f28f737.json
@@ -1,0 +1,55 @@
+{
+  "opendb_id": "f6f51e26-3ec7-40f2-a43b-13aa1f28f737",
+  "metadata": {
+    "name": "REDMI Buds 8 Lite Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Buds 8 Lite",
+    "part_numbers": [],
+    "variant": "Blue"
+  },
+  "ear_cup_type": "Earbuds",
+  "connection_types": ["Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-buds-8-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554471927",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "71617",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "71617",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "71617",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "71617",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/00668ab5-c00a-440a-8276-d4db70dcdb72.json
+++ b/open-db/Keyboard/00668ab5-c00a-440a-8276-d4db70dcdb72.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "00668ab5-c00a-440a-8276-d4db70dcdb72",
+  "metadata": {
+    "name": "Xiaomi Pad 7 / 7 Pro Keyboard Spanish Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 7 / 7 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Spanish Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-pad-7-7-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812734223",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "60283",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/022dc9f9-3990-4ca9-960d-2e8163926140.json
+++ b/open-db/Keyboard/022dc9f9-3990-4ca9-960d-2e8163926140.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "022dc9f9-3990-4ca9-960d-2e8163926140",
+  "metadata": {
+    "name": "REDMI Pad Pro Keyboard Italian Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Italian Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-pad-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812785157",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "56651",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/0371781f-8f29-450d-b438-1990182a461a.json
+++ b/open-db/Keyboard/0371781f-8f29-450d-b438-1990182a461a.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "0371781f-8f29-450d-b438-1990182a461a",
+  "metadata": {
+    "name": "Xiaomi Pad 7 / 7 Pro Focus Keyboard Italian Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 7 / 7 Pro Focus Keyboard",
+    "part_numbers": [],
+    "variant": "Italian Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-pad-7-7-pro-focus-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554419882",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "63289",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/0877ffcc-10a9-4229-8c9c-e36afe8a52e9.json
+++ b/open-db/Keyboard/0877ffcc-10a9-4229-8c9c-e36afe8a52e9.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "0877ffcc-10a9-4229-8c9c-e36afe8a52e9",
+  "metadata": {
+    "name": "Xiaomi Pad 7 / 7 Pro Keyboard Italian Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 7 / 7 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Italian Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-pad-7-7-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554419868",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "63287",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/093e2be3-df92-47a5-8d80-d9a57e1a3235.json
+++ b/open-db/Keyboard/093e2be3-df92-47a5-8d80-d9a57e1a3235.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "093e2be3-df92-47a5-8d80-d9a57e1a3235",
+  "metadata": {
+    "name": "Xiaomi Pad 8 / 8 Pro Keyboard Spanish Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Spanish Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-pad-8-8-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554479046",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "72537",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/0b652270-6976-47b4-a139-677c84ac54c2.json
+++ b/open-db/Keyboard/0b652270-6976-47b4-a139-677c84ac54c2.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "0b652270-6976-47b4-a139-677c84ac54c2",
+  "metadata": {
+    "name": "Xiaomi Pad 8 / 8 Pro Keyboard Italian Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Italian Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-pad-8-8-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554479145",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "72547",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/13808c5d-a1bf-4c9c-a152-d08683b85cc6.json
+++ b/open-db/Keyboard/13808c5d-a1bf-4c9c-a152-d08683b85cc6.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "13808c5d-a1bf-4c9c-a152-d08683b85cc6",
+  "metadata": {
+    "name": "REDMI Pad Pro Keyboard UK English Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad Pro Keyboard",
+    "part_numbers": [],
+    "variant": "UK English Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/redmi-pad-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812785133",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "56649",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/1413547c-1ced-48c4-9122-67caf2719cfc.json
+++ b/open-db/Keyboard/1413547c-1ced-48c4-9122-67caf2719cfc.json
@@ -1,24 +1,21 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "1413547c-1ced-48c4-9122-67caf2719cfc",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "REDMI Pad Pro Keyboard Polish Layout",
     "manufacturer": "Xiaomi",
+    "series": "Pad Pro Keyboard",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "Polish Layout"
   },
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/redmi-pad-pro-keyboard/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812785164",
         "region": "all"
       }
     ],
@@ -26,7 +23,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "56652",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Keyboard/16518a7d-e2df-41f8-a43c-ad13ccc8ec24.json
+++ b/open-db/Keyboard/16518a7d-e2df-41f8-a43c-ad13ccc8ec24.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "16518a7d-e2df-41f8-a43c-ad13ccc8ec24",
+  "metadata": {
+    "name": "Xiaomi Pad 8 / 8 Pro Focus Keyboard Spanish Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Focus Keyboard",
+    "part_numbers": [],
+    "variant": "Spanish Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-pad-8-8-pro-focus-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554479114",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "72544",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/29473a5f-d6ea-4b7e-b325-26bd1240e006.json
+++ b/open-db/Keyboard/29473a5f-d6ea-4b7e-b325-26bd1240e006.json
@@ -1,24 +1,21 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "29473a5f-d6ea-4b7e-b325-26bd1240e006",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "POCO Pad M1 Keyboard Polish Layout",
     "manufacturer": "Xiaomi",
+    "series": "Pad M1 Keyboard",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "Polish Layout"
   },
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/poco-pad-m1-keyboard/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6932554472535",
         "region": "all"
       }
     ],
@@ -26,7 +23,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "71683",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Keyboard/2e0fd1f8-63e4-487e-87b2-166a5524ae22.json
+++ b/open-db/Keyboard/2e0fd1f8-63e4-487e-87b2-166a5524ae22.json
@@ -1,0 +1,39 @@
+{
+  "opendb_id": "2e0fd1f8-63e4-487e-87b2-166a5524ae22",
+  "metadata": {
+    "name": "Xiaomi Pad 7 / 7 Pro Focus Keyboard US English Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 7 / 7 Pro Focus Keyboard",
+    "part_numbers": [],
+    "variant": "US English Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-pad-7-7-pro-focus-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812703724",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "60263",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "60263",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/2ed19fe5-1024-4e99-aa95-efa3f2d02ff0.json
+++ b/open-db/Keyboard/2ed19fe5-1024-4e99-aa95-efa3f2d02ff0.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "2ed19fe5-1024-4e99-aa95-efa3f2d02ff0",
+  "metadata": {
+    "name": "Xiaomi Pad 8 / 8 Pro Keyboard UK English Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "UK English Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-pad-8-8-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554479077",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "72540",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/330ba5f7-6794-47c3-96a6-e711a34c7091.json
+++ b/open-db/Keyboard/330ba5f7-6794-47c3-96a6-e711a34c7091.json
@@ -1,24 +1,21 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "330ba5f7-6794-47c3-96a6-e711a34c7091",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Pad 6S Pro Touchpad Keyboard Polish Layout",
     "manufacturer": "Xiaomi",
+    "series": "Pad 6S Pro Touchpad Keyboard",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "Polish Layout"
   },
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-pad-6s-pro-touchpad-keyboard/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812778852",
         "region": "all"
       }
     ],
@@ -26,7 +23,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "55864",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Keyboard/4db33b39-1e43-42fb-afa4-b40e14180129.json
+++ b/open-db/Keyboard/4db33b39-1e43-42fb-afa4-b40e14180129.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "4db33b39-1e43-42fb-afa4-b40e14180129",
+  "metadata": {
+    "name": "Xiaomi Pad 7 / 7 Pro Focus Keyboard Spanish Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 7 / 7 Pro Focus Keyboard",
+    "part_numbers": [],
+    "variant": "Spanish Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-pad-7-7-pro-focus-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812733660",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "60278",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/6994dd39-8e15-4ca8-8d2a-e068f74d84c1.json
+++ b/open-db/Keyboard/6994dd39-8e15-4ca8-8d2a-e068f74d84c1.json
@@ -1,24 +1,21 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "6994dd39-8e15-4ca8-8d2a-e068f74d84c1",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Pad 8 / 8 Pro Keyboard Polish Layout",
     "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Keyboard",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "Polish Layout"
   },
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-pad-8-8-pro-keyboard/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6932554479121",
         "region": "all"
       }
     ],
@@ -26,7 +23,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "72545",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Keyboard/8250f3ee-fcdc-4070-a48c-3be03bbb7aa7.json
+++ b/open-db/Keyboard/8250f3ee-fcdc-4070-a48c-3be03bbb7aa7.json
@@ -1,24 +1,21 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "8250f3ee-fcdc-4070-a48c-3be03bbb7aa7",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "REDMI Pad 2 Pro Keyboard US English Layout",
     "manufacturer": "Xiaomi",
+    "series": "Pad 2 Pro Keyboard",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "US English Layout"
   },
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/redmi-pad-2-pro-keyboard/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6932554464691",
         "region": "all"
       }
     ],
@@ -26,7 +23,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "70591",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Keyboard/87e69c7c-1fc6-426e-a20a-e8f7017ce580.json
+++ b/open-db/Keyboard/87e69c7c-1fc6-426e-a20a-e8f7017ce580.json
@@ -1,24 +1,21 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "87e69c7c-1fc6-426e-a20a-e8f7017ce580",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Pad 8 / 8 Pro Focus Keyboard Polish Layout",
     "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Focus Keyboard",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "Polish Layout"
   },
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-pad-8-8-pro-focus-keyboard/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6932554478995",
         "region": "all"
       }
     ],
@@ -26,7 +23,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "72532",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Keyboard/92b5d24b-0c56-47c0-9070-a31cd62eada1.json
+++ b/open-db/Keyboard/92b5d24b-0c56-47c0-9070-a31cd62eada1.json
@@ -1,0 +1,39 @@
+{
+  "opendb_id": "92b5d24b-0c56-47c0-9070-a31cd62eada1",
+  "metadata": {
+    "name": "Xiaomi Pad 7 / 7 Pro Keyboard US English Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 7 / 7 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "US English Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-pad-7-7-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812738023",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "60285",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "60285",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/aaf5b370-7e3e-4c27-9db7-e125d7ba25bf.json
+++ b/open-db/Keyboard/aaf5b370-7e3e-4c27-9db7-e125d7ba25bf.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "aaf5b370-7e3e-4c27-9db7-e125d7ba25bf",
+  "metadata": {
+    "name": "Xiaomi Pad 8 / 8 Pro Focus Keyboard Italian Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Focus Keyboard",
+    "part_numbers": [],
+    "variant": "Italian Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-pad-8-8-pro-focus-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554479107",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "72543",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/bb50d7d5-6dde-42fe-ad2d-28a1ca493781.json
+++ b/open-db/Keyboard/bb50d7d5-6dde-42fe-ad2d-28a1ca493781.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "bb50d7d5-6dde-42fe-ad2d-28a1ca493781",
+  "metadata": {
+    "name": "Xiaomi Pad 8 / 8 Pro Focus Keyboard UK English Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 8 / 8 Pro Focus Keyboard",
+    "part_numbers": [],
+    "variant": "UK English Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-pad-8-8-pro-focus-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554479015",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "72534",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/c771f3ca-0c31-485b-97be-ea51ea19c028.json
+++ b/open-db/Keyboard/c771f3ca-0c31-485b-97be-ea51ea19c028.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "c771f3ca-0c31-485b-97be-ea51ea19c028",
+  "metadata": {
+    "name": "REDMI Pad 2 Pro Keyboard UK English Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 2 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "UK English Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/redmi-pad-2-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554464677",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70589",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/cde67b9a-064e-4e3c-81e6-3cebe8a0eb4c.json
+++ b/open-db/Keyboard/cde67b9a-064e-4e3c-81e6-3cebe8a0eb4c.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "cde67b9a-064e-4e3c-81e6-3cebe8a0eb4c",
+  "metadata": {
+    "name": "REDMI Pad 2 Pro Keyboard Italian Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 2 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Italian Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/redmi-pad-2-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554464424",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70592",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/ce227349-e2d8-4a3b-b49a-e838001c816d.json
+++ b/open-db/Keyboard/ce227349-e2d8-4a3b-b49a-e838001c816d.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "ce227349-e2d8-4a3b-b49a-e838001c816d",
+  "metadata": {
+    "name": "REDMI Pad Pro Keyboard Spanish Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Spanish Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/redmi-pad-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812785126",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "56648",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Keyboard/d8de61ba-d321-4d13-9069-af7e8c99e91d.json
+++ b/open-db/Keyboard/d8de61ba-d321-4d13-9069-af7e8c99e91d.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "d8de61ba-d321-4d13-9069-af7e8c99e91d",
+  "metadata": {
+    "name": "REDMI Pad 2 Pro Keyboard Spanish Layout",
+    "manufacturer": "Xiaomi",
+    "series": "Pad 2 Pro Keyboard",
+    "part_numbers": [],
+    "variant": "Spanish Layout"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/redmi-pad-2-pro-keyboard/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554464684",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70590",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/0a6a0f7e-d826-4474-b7c8-1957164bece2.json
+++ b/open-db/Lighting/0a6a0f7e-d826-4474-b7c8-1957164bece2.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "0a6a0f7e-d826-4474-b7c8-1957164bece2",
+  "metadata": {
+    "name": "Xiaomi Desk Lamp Lite EU Plug",
+    "manufacturer": "Xiaomi",
+    "series": "Desk Lamp Lite",
+    "part_numbers": [],
+    "variant": "EU Plug"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-desk-lamp-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812795941",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "58220",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "58220",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "58220",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/3869b0b8-64a3-4bf5-93ef-2c48473c256c.json
+++ b/open-db/Lighting/3869b0b8-64a3-4bf5-93ef-2c48473c256c.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "3869b0b8-64a3-4bf5-93ef-2c48473c256c",
+  "metadata": {
+    "name": "Mi Smart LED Desk Lamp Pro White",
+    "manufacturer": "Xiaomi",
+    "series": "Smart LED Desk Lamp Pro",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/mi-smart-led-desk-lamp-pro/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177763137",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "39492",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "39492",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "39492",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/6e9ea0d4-8912-45dc-9970-481187a72fae.json
+++ b/open-db/Lighting/6e9ea0d4-8912-45dc-9970-481187a72fae.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "6e9ea0d4-8912-45dc-9970-481187a72fae",
+  "metadata": {
+    "name": "Mi Computer Monitor Light Bar Black",
+    "manufacturer": "Xiaomi",
+    "series": "Computer Monitor Light Bar",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/mi-computer-monitor-light-bar/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177728525",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "30769",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "30769",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "30769",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "30769",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/84ed9542-5acc-40f6-8b6a-84637ccca7a6.json
+++ b/open-db/Lighting/84ed9542-5acc-40f6-8b6a-84637ccca7a6.json
@@ -1,0 +1,52 @@
+{
+  "opendb_id": "84ed9542-5acc-40f6-8b6a-84637ccca7a6",
+  "metadata": {
+    "name": "Xiaomi Flexible Rechargeable Lamp",
+    "manufacturer": "Xiaomi",
+    "series": "Flexible Rechargeable Lamp",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-flexible-rechargeable-lamp/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812795958",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "58232",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "58232",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "58232",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "58232",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/9b5d96cb-59ea-4f3b-ac99-baaf0acca4c1.json
+++ b/open-db/Lighting/9b5d96cb-59ea-4f3b-ac99-baaf0acca4c1.json
@@ -1,0 +1,52 @@
+{
+  "opendb_id": "9b5d96cb-59ea-4f3b-ac99-baaf0acca4c1",
+  "metadata": {
+    "name": "Xiaomi Magnetic Reading Light Bar",
+    "manufacturer": "Xiaomi",
+    "series": "Magnetic Reading Light Bar",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-magnetic-reading-light-bar/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812795910",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "58221",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "58221",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "58221",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "58221",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/a2bada61-0ccd-4e2d-9ec6-2b0a78cb258f.json
+++ b/open-db/Lighting/a2bada61-0ccd-4e2d-9ec6-2b0a78cb258f.json
@@ -1,0 +1,52 @@
+{
+  "opendb_id": "a2bada61-0ccd-4e2d-9ec6-2b0a78cb258f",
+  "metadata": {
+    "name": "Xiaomi LED Desk Lamp 2",
+    "manufacturer": "Xiaomi",
+    "series": "LED Desk Lamp 2",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-led-desk-lamp-2/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812706961",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "58881",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "58881",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "58881",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "58881",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/e4efffc1-8c9f-4b74-8a50-a10da3d30178.json
+++ b/open-db/Lighting/e4efffc1-8c9f-4b74-8a50-a10da3d30178.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "e4efffc1-8c9f-4b74-8a50-a10da3d30178",
+  "metadata": {
+    "name": "Xiaomi Desk Lamp Lite UK Plug",
+    "manufacturer": "Xiaomi",
+    "series": "Desk Lamp Lite",
+    "part_numbers": [],
+    "variant": "UK Plug"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-desk-lamp-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812795927",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "58249",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Lighting/ff334f05-b140-4841-9f11-7517f3626895.json
+++ b/open-db/Lighting/ff334f05-b140-4841-9f11-7517f3626895.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "ff334f05-b140-4841-9f11-7517f3626895",
+  "metadata": {
+    "name": "Mi LED Desk Lamp 1S White",
+    "manufacturer": "Xiaomi",
+    "series": "LED Desk Lamp 1S",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/mi-led-desk-lamp-1s/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177763113",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "39491",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "39491",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "39491",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/0559965e-36e5-4db0-ab28-009bdcc4d6ff.json
+++ b/open-db/Monitor/0559965e-36e5-4db0-ab28-009bdcc4d6ff.json
@@ -1,0 +1,72 @@
+{
+  "opendb_id": "0559965e-36e5-4db0-ab28-009bdcc4d6ff",
+  "metadata": {
+    "name": "Xiaomi Mini LED Gaming Monitor G Pro 27Qi 2026",
+    "manufacturer": "Xiaomi",
+    "series": "Mini LED Gaming Monitor G Pro 27Qi",
+    "part_numbers": [],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 2560,
+    "verticalRes": 1440
+  },
+  "refresh_rate": 180,
+  "panel_type": "Mini LED IPS",
+  "response_time": 1,
+  "max_brightness": 2000,
+  "aspect_ratio": "16:9",
+  "connectors": "2 x DisplayPort 1.4; 2 x HDMI 2.0; 1 x 3.5 mm audio",
+  "adaptive_sync": "VESA Adaptive-Sync",
+  "hdr": "Mini LED HDR",
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-mini-led-gaming-monitor-g-pro-27qi/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948707900",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948708228",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "69117",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "69117",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "69117",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "69121",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/072de9f2-9494-4eb6-b4d7-2bb0e827e021.json
+++ b/open-db/Monitor/072de9f2-9494-4eb6-b4d7-2bb0e827e021.json
@@ -1,0 +1,76 @@
+{
+  "opendb_id": "072de9f2-9494-4eb6-b4d7-2bb0e827e021",
+  "metadata": {
+    "name": "Xiaomi 4K Monitor A27Ui",
+    "manufacturer": "Xiaomi",
+    "series": "4K Monitor A27Ui",
+    "part_numbers": ["P27UCB-RAGL"]
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 3840,
+    "verticalRes": 2160
+  },
+  "refresh_rate": 60,
+  "panel_type": "IPS",
+  "response_time": 6,
+  "max_brightness": 360,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x DisplayPort; 2 x HDMI; 1 x USB-C; 2 x USB 2.0 Type-A; 1 x 3.5 mm audio",
+  "hdr": "HDR10",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-4k-monitor-a27ui/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948706989",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948707009",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P27UCB-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "66380",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "66380",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "66380",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "66384",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/0a243538-5bd1-4cea-8753-206ae64e0e49.json
+++ b/open-db/Monitor/0a243538-5bd1-4cea-8753-206ae64e0e49.json
@@ -1,0 +1,48 @@
+{
+  "opendb_id": "0a243538-5bd1-4cea-8753-206ae64e0e49",
+  "metadata": {
+    "name": "Xiaomi Monitor A24i",
+    "manufacturer": "Xiaomi",
+    "series": "Monitor A24i",
+    "part_numbers": ["P24FBA-RAGL"]
+  },
+  "screen_size": 23.8,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 100,
+  "panel_type": "IPS",
+  "response_time": 6,
+  "max_brightness": 250,
+  "aspect_ratio": "16:9",
+  "connectors": "1 x DisplayPort 1.4; 1 x HDMI",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-monitor-a24i/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948701908",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P24FBA-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "54383",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/2964efd0-bb50-48b8-bde1-cf415ee3df4f.json
+++ b/open-db/Monitor/2964efd0-bb50-48b8-bde1-cf415ee3df4f.json
@@ -1,0 +1,62 @@
+{
+  "opendb_id": "2964efd0-bb50-48b8-bde1-cf415ee3df4f",
+  "metadata": {
+    "name": "Xiaomi Monitor A27i",
+    "manufacturer": "Xiaomi",
+    "series": "Monitor A27i",
+    "part_numbers": ["P27FBA-RAGL"]
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 100,
+  "panel_type": "IPS",
+  "response_time": 6,
+  "max_brightness": 250,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x DisplayPort; 1 x HDMI 2.0",
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-monitor-a27i/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948701199",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P27FBA-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "51054",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "51054",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "51054",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/335ba699-9a0e-4cb4-ad28-bf8ac4398108.json
+++ b/open-db/Monitor/335ba699-9a0e-4cb4-ad28-bf8ac4398108.json
@@ -1,0 +1,54 @@
+{
+  "opendb_id": "335ba699-9a0e-4cb4-ad28-bf8ac4398108",
+  "metadata": {
+    "name": "Xiaomi Gaming Monitor G25i 2026",
+    "manufacturer": "Xiaomi",
+    "series": "Gaming Monitor G25i",
+    "part_numbers": [],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 24.5,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 240,
+  "panel_type": "IPS",
+  "response_time": 1,
+  "max_brightness": 400,
+  "aspect_ratio": "16:9",
+  "connectors": "1 x DisplayPort 1.4; 1 x HDMI 2.0",
+  "adaptive_sync": "FreeSync Premium",
+  "hdr": "DisplayHDR 400",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-gaming-monitor-g25i-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948710320",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "75847",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "75847",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/3d3736ee-5fd7-4f3d-aa1d-5040f079af19.json
+++ b/open-db/Monitor/3d3736ee-5fd7-4f3d-aa1d-5040f079af19.json
@@ -1,0 +1,77 @@
+{
+  "opendb_id": "3d3736ee-5fd7-4f3d-aa1d-5040f079af19",
+  "metadata": {
+    "name": "Xiaomi Monitor A27i 2026",
+    "manufacturer": "Xiaomi",
+    "series": "Monitor A27i",
+    "part_numbers": ["P27FDA-RAGL"],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 144,
+  "panel_type": "IPS",
+  "response_time": 6,
+  "max_brightness": 300,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x DisplayPort 1.4; 1 x HDMI 2.0",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-monitor-a27i-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948708334",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948708358",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P27FDA-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "69664",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "69664",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "69664",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "69668",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/5a14d5ea-1e68-4d2a-9c85-2aca90e99c96.json
+++ b/open-db/Monitor/5a14d5ea-1e68-4d2a-9c85-2aca90e99c96.json
@@ -1,0 +1,76 @@
+{
+  "opendb_id": "5a14d5ea-1e68-4d2a-9c85-2aca90e99c96",
+  "metadata": {
+    "name": "Xiaomi 2K Monitor A27Qi 2026",
+    "manufacturer": "Xiaomi",
+    "series": "2K Monitor A27Qi",
+    "part_numbers": ["P27QDA-RAGL"],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 2560,
+    "verticalRes": 1440
+  },
+  "refresh_rate": 120,
+  "panel_type": "IPS",
+  "response_time": 6,
+  "max_brightness": 300,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x DisplayPort 1.4; 1 x HDMI 2.0; 1 x 3.5 mm audio",
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-2k-monitor-a27qi-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948709133",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948709157",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P27QDA-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70857",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70857",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70857",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70861",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/5a228ba2-03a5-4eb4-a639-3a93f8b5e6aa.json
+++ b/open-db/Monitor/5a228ba2-03a5-4eb4-a639-3a93f8b5e6aa.json
@@ -1,0 +1,70 @@
+{
+  "opendb_id": "5a228ba2-03a5-4eb4-a639-3a93f8b5e6aa",
+  "metadata": {
+    "name": "Xiaomi Gaming Monitor G27i 2026",
+    "manufacturer": "Xiaomi",
+    "series": "Gaming Monitor G27i",
+    "part_numbers": [],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 200,
+  "panel_type": "IPS",
+  "response_time": 1,
+  "aspect_ratio": "16:9",
+  "connectors": "1 x DisplayPort 1.4; 1 x HDMI 2.0; 1 x 3.5 mm audio",
+  "adaptive_sync": "FreeSync Premium",
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-gaming-monitor-g27i-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948708013",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948708037",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "68559",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "68559",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "68559",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "68563",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/65d52c1c-e075-45bd-9eea-6af54b82f7d9.json
+++ b/open-db/Monitor/65d52c1c-e075-45bd-9eea-6af54b82f7d9.json
@@ -1,0 +1,63 @@
+{
+  "opendb_id": "65d52c1c-e075-45bd-9eea-6af54b82f7d9",
+  "metadata": {
+    "name": "Xiaomi 2K Monitor A27Qi",
+    "manufacturer": "Xiaomi",
+    "series": "2K Monitor A27Qi",
+    "part_numbers": ["P27QCA-RAGL"]
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 2560,
+    "verticalRes": 1440
+  },
+  "refresh_rate": 100,
+  "panel_type": "IPS",
+  "response_time": 6,
+  "max_brightness": 250,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x DisplayPort; 1 x HDMI; 1 x 3.5 mm audio",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-2k-monitor-a27qi/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948704794",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P27QCA-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "63059",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "63059",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "63059",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/6cc156b6-851a-49bb-a2ad-d1fd494cd377.json
+++ b/open-db/Monitor/6cc156b6-851a-49bb-a2ad-d1fd494cd377.json
@@ -10,14 +10,14 @@
   "response_time": 1,
   "color": ["BLACK"],
   "lighting": [],
-  "viewing_angle": "178 H x 178° V",
+  "viewing_angle": "178 H x 178\u00b0 V",
   "aspect_ratio": "16:9",
   "connectors": "2 x HDMI 2.0                                                    2 x DisplayPort 1.4",
-  "max_brightness": 250,
+  "max_brightness": 300,
   "hdr": "",
   "adaptive_sync": "VESA Adaptive-Sync",
   "metadata": {
-    "name": "Xiaomi Redmi Gaming Monitor X27GQ 2025 P27QCA-RX",
+    "name": "Xiaomi 2K Gaming Monitor G27Qi",
     "manufacturer": "Xiaomi",
     "part_numbers": [
       "P27QCA-RX",
@@ -26,10 +26,12 @@
       "Redmi Gaming Monitor X27GQ 2025 P27QCA-RX",
       "ELA6556EU"
     ],
-    "series": "",
+    "series": "2K Gaming Monitor G27Qi",
     "variant": ""
   },
-  "general_product_information": {},
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/global/product/xiaomi-2k-gaming-monitor-g27qi/"
+  },
   "identifiers": {
     "version": 1,
     "identifiers": [
@@ -40,12 +42,7 @@
       },
       {
         "type": "ean",
-        "value": "6941948709072",
-        "region": "all"
-      },
-      {
-        "type": "ean",
-        "value": "6941948709096",
+        "value": "6941948703254",
         "region": "all"
       },
       {
@@ -149,6 +146,34 @@
         "source_product_id": "3317958",
         "pricing_enabled": true,
         "verified": false
+      },
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57457",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57457",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57457",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57461",
+        "pricing_enabled": true,
+        "verified": true
       }
     ]
   }

--- a/open-db/Monitor/73042a62-44bd-47ce-a032-9217d4a901b0.json
+++ b/open-db/Monitor/73042a62-44bd-47ce-a032-9217d4a901b0.json
@@ -10,7 +10,7 @@
   "response_time": 0,
   "color": ["BLACK", "GREY"],
   "lighting": [],
-  "viewing_angle": "178° H x 178° V",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
   "aspect_ratio": "16:9",
   "connectors": "2 x HDMI 2.0                                            2 x DisplayPort 1.4",
   "max_brightness": 1000,
@@ -30,6 +30,16 @@
       {
         "type": "ean",
         "value": "0190997006267",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948703193",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948703209",
         "region": "all"
       },
       {
@@ -160,6 +170,34 @@
         "source_product_id": "6776516893",
         "pricing_enabled": true,
         "verified": false
+      },
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57449",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57449",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57449",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57451",
+        "pricing_enabled": true,
+        "verified": true
       }
     ]
   }

--- a/open-db/Monitor/88f2dbca-53e9-47dd-a339-3f615520de8d.json
+++ b/open-db/Monitor/88f2dbca-53e9-47dd-a339-3f615520de8d.json
@@ -1,0 +1,51 @@
+{
+  "opendb_id": "88f2dbca-53e9-47dd-a339-3f615520de8d",
+  "metadata": {
+    "name": "Xiaomi Gaming Monitor G24i",
+    "manufacturer": "Xiaomi",
+    "series": "Gaming Monitor G24i",
+    "part_numbers": ["P24FCA-RGGL"]
+  },
+  "screen_size": 23.8,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 180,
+  "panel_type": "IPS",
+  "response_time": 1,
+  "max_brightness": 250,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x DisplayPort 1.4; 1 x HDMI 2.0; 1 x 3.5 mm audio",
+  "adaptive_sync": "FreeSync",
+  "hdr": "HDR",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-gaming-monitor-g24i/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948703353",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P24FCA-RGGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57900",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/8e913128-6bee-460b-89be-42590808bca1.json
+++ b/open-db/Monitor/8e913128-6bee-460b-89be-42590808bca1.json
@@ -10,17 +10,17 @@
   "response_time": 1,
   "color": ["BLACK"],
   "lighting": [],
-  "viewing_angle": "178 H x 178° V",
+  "viewing_angle": "178 H x 178\u00b0 V",
   "aspect_ratio": "16:9",
   "connectors": "1 x HDMI 2.0                                                    1 x DisplayPort 1.2",
   "max_brightness": 250,
   "hdr": "",
   "adaptive_sync": "VESA Adaptive-Sync",
   "metadata": {
-    "name": "Xiaomi Redmi Display G27 P27FBB-RG",
+    "name": "Xiaomi Gaming Monitor G27i",
     "manufacturer": "Xiaomi",
     "part_numbers": ["P27FBB-RG", "Redmi Display G27 P27FBB-RG"],
-    "series": "",
+    "series": "Gaming Monitor G27i",
     "variant": ""
   },
   "general_product_information": {
@@ -32,6 +32,16 @@
       {
         "type": "ean",
         "value": "6941948700031",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948701403",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948701427",
         "region": "all"
       },
       {
@@ -148,6 +158,27 @@
         "source": "amazon",
         "channel": "us",
         "source_product_id": "B0DDVZF8BG",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "52756",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "52756",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "52760",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Monitor/aed7362d-eb27-4b00-8f8a-b95b40d9cad0.json
+++ b/open-db/Monitor/aed7362d-eb27-4b00-8f8a-b95b40d9cad0.json
@@ -1,0 +1,64 @@
+{
+  "opendb_id": "aed7362d-eb27-4b00-8f8a-b95b40d9cad0",
+  "metadata": {
+    "name": "Xiaomi Curved Gaming Monitor G34WQi",
+    "manufacturer": "Xiaomi",
+    "series": "Curved Gaming Monitor G34WQi",
+    "part_numbers": ["C34WQBA-RGGL"]
+  },
+  "screen_size": 34,
+  "resolution": {
+    "horizontalRes": 3440,
+    "verticalRes": 1440
+  },
+  "refresh_rate": 180,
+  "panel_type": "VA",
+  "mprt_response_time": 1,
+  "max_brightness": 350,
+  "aspect_ratio": "21:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "2 x DisplayPort 1.4; 2 x HDMI 2.0; 1 x 3.5 mm audio",
+  "adaptive_sync": "FreeSync Premium",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-curved-gaming-monitor-g34wqi/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948702097",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "C34WQBA-RGGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "55056",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "55056",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "55056",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/d23237dc-0e0d-4264-b771-a4d0a5756798.json
+++ b/open-db/Monitor/d23237dc-0e0d-4264-b771-a4d0a5756798.json
@@ -1,0 +1,74 @@
+{
+  "opendb_id": "d23237dc-0e0d-4264-b771-a4d0a5756798",
+  "metadata": {
+    "name": "Xiaomi Monitor A22i",
+    "manufacturer": "Xiaomi",
+    "series": "Monitor A22i",
+    "part_numbers": ["A22FAB-RAGL"]
+  },
+  "screen_size": 21.45,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 75,
+  "panel_type": "VA",
+  "max_brightness": 250,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x HDMI 1.4; 1 x VGA",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-monitor-a22i/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948700314",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948700338",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "A22FAB-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "48341",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "48341",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "48341",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "48345",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/d6f6a9b2-447e-4f7d-9c6c-5834b09aef31.json
+++ b/open-db/Monitor/d6f6a9b2-447e-4f7d-9c6c-5834b09aef31.json
@@ -1,0 +1,79 @@
+{
+  "opendb_id": "d6f6a9b2-447e-4f7d-9c6c-5834b09aef31",
+  "metadata": {
+    "name": "Xiaomi 2K Gaming Monitor G27Qi 2026",
+    "manufacturer": "Xiaomi",
+    "series": "2K Gaming Monitor G27Qi",
+    "variant": "2026",
+    "releaseYear": 2026,
+    "part_numbers": ["P27QDB-RGGL"]
+  },
+  "screen_size": 27,
+  "resolution": {
+    "horizontalRes": 2560,
+    "verticalRes": 1440
+  },
+  "refresh_rate": 200,
+  "panel_type": "IPS",
+  "response_time": 1,
+  "lighting": ["None"],
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "aspect_ratio": "16:9",
+  "connectors": "2 x DisplayPort 1.4; 2 x HDMI 2.0; 1 x 3.5 mm audio",
+  "max_brightness": 400,
+  "hdr": "DisplayHDR 400",
+  "adaptive_sync": "FreeSync Premium",
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-2k-gaming-monitor-g27qi-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948709072",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948709096",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P27QDB-RGGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70845",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70845",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70845",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70849",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/d7ada818-0a2e-4042-90b9-b891aee176f7.json
+++ b/open-db/Monitor/d7ada818-0a2e-4042-90b9-b891aee176f7.json
@@ -1,0 +1,77 @@
+{
+  "opendb_id": "d7ada818-0a2e-4042-90b9-b891aee176f7",
+  "metadata": {
+    "name": "Xiaomi Monitor A24i 2026",
+    "manufacturer": "Xiaomi",
+    "series": "Monitor A24i",
+    "part_numbers": ["P24FDA-RAGL"],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 23.8,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 144,
+  "panel_type": "IPS",
+  "response_time": 6,
+  "max_brightness": 300,
+  "aspect_ratio": "16:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "1 x DisplayPort 1.4; 1 x HDMI 2.0",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-monitor-a24i-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948708365",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948708389",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P24FDA-RAGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "69670",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "69670",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "69670",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "69674",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/e49e0674-049f-42ad-987a-1981c9911b76.json
+++ b/open-db/Monitor/e49e0674-049f-42ad-987a-1981c9911b76.json
@@ -1,0 +1,76 @@
+{
+  "opendb_id": "e49e0674-049f-42ad-987a-1981c9911b76",
+  "metadata": {
+    "name": "Xiaomi Gaming Monitor G24i 2026",
+    "manufacturer": "Xiaomi",
+    "series": "Gaming Monitor G24i",
+    "part_numbers": ["P24FDA-RGGL"],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 23.8,
+  "resolution": {
+    "horizontalRes": 1920,
+    "verticalRes": 1080
+  },
+  "refresh_rate": 200,
+  "panel_type": "IPS",
+  "response_time": 1,
+  "max_brightness": 400,
+  "aspect_ratio": "16:9",
+  "connectors": "1 x DisplayPort; 1 x HDMI; 1 x 3.5 mm audio",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-gaming-monitor-g24i-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948707979",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948707993",
+        "region": "all"
+      },
+      {
+        "type": "mpn",
+        "value": "P24FDA-RGGL",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "68364",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "68364",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "68364",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "68368",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Monitor/e808947a-c7ca-4342-a685-7df6f470938d.json
+++ b/open-db/Monitor/e808947a-c7ca-4342-a685-7df6f470938d.json
@@ -1,0 +1,72 @@
+{
+  "opendb_id": "e808947a-c7ca-4342-a685-7df6f470938d",
+  "metadata": {
+    "name": "Xiaomi Curved Gaming Monitor G34WQi 2026",
+    "manufacturer": "Xiaomi",
+    "series": "Curved Gaming Monitor G34WQi",
+    "part_numbers": [],
+    "variant": "2026",
+    "releaseYear": 2026
+  },
+  "screen_size": 34,
+  "resolution": {
+    "horizontalRes": 3440,
+    "verticalRes": 1440
+  },
+  "refresh_rate": 180,
+  "panel_type": "VA",
+  "response_time": 1,
+  "max_brightness": 400,
+  "aspect_ratio": "21:9",
+  "viewing_angle": "178\u00b0 H x 178\u00b0 V",
+  "connectors": "2 x DisplayPort 1.4; 2 x HDMI 2.0; 1 x 3.5 mm audio",
+  "lighting": ["None"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-curved-gaming-monitor-g34wqi-2026/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948709102",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948709126",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70851",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70851",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70851",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70855",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Mouse/00032cf7-b98e-4794-96a4-de90d278bc21.json
+++ b/open-db/Mouse/00032cf7-b98e-4794-96a4-de90d278bc21.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "00032cf7-b98e-4794-96a4-de90d278bc21",
+  "metadata": {
+    "name": "Xiaomi Wireless Mouse Lite Black",
+    "manufacturer": "Xiaomi",
+    "series": "Wireless Mouse Lite",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "connectivity": ["Wireless 2.4GHz"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-wireless-mouse-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177787096",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "40472",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "40472",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Mouse/013cc20a-a1b0-4a77-86d6-890a15690b13.json
+++ b/open-db/Mouse/013cc20a-a1b0-4a77-86d6-890a15690b13.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "013cc20a-a1b0-4a77-86d6-890a15690b13",
+  "metadata": {
+    "name": "Xiaomi Gaming Mouse Lite",
+    "manufacturer": "Xiaomi",
+    "series": "Gaming Mouse Lite",
+    "part_numbers": []
+  },
+  "connectivity": ["Wired USB-A"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-gaming-mouse-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812792421",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57884",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Mouse/1063cd1a-3361-4585-a67a-b8bc03f26115.json
+++ b/open-db/Mouse/1063cd1a-3361-4585-a67a-b8bc03f26115.json
@@ -1,24 +1,22 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "1063cd1a-3361-4585-a67a-b8bc03f26115",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Dual-mode Wireless Mouse 2 White",
     "manufacturer": "Xiaomi",
+    "series": "Dual-mode Wireless Mouse 2",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "White"
   },
+  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-dual-mode-wireless-mouse-2/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812792223",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "57863",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/2c2bfc35-f2cb-4166-947a-07ae7321abdd.json
+++ b/open-db/Mouse/2c2bfc35-f2cb-4166-947a-07ae7321abdd.json
@@ -1,24 +1,22 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "2c2bfc35-f2cb-4166-947a-07ae7321abdd",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Dual-mode Wireless Mouse 2 Black",
     "manufacturer": "Xiaomi",
+    "series": "Dual-mode Wireless Mouse 2",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
     "variant": "Black"
   },
+  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-dual-mode-wireless-mouse-2/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812792216",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "57864",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/2dfd9702-edff-4060-9579-94ad22e047d0.json
+++ b/open-db/Mouse/2dfd9702-edff-4060-9579-94ad22e047d0.json
@@ -1,0 +1,40 @@
+{
+  "opendb_id": "2dfd9702-edff-4060-9579-94ad22e047d0",
+  "metadata": {
+    "name": "Mi Dual Mode Wireless Mouse Silent Edition White",
+    "manufacturer": "Xiaomi",
+    "series": "Dual Mode Wireless Mouse Silent Edition",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://ams.buy.mi.com/uk/item/3204800029"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177715440",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "26111",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "26111",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Mouse/69588eae-a012-48dd-a8f3-fc8a20de0e8c.json
+++ b/open-db/Mouse/69588eae-a012-48dd-a8f3-fc8a20de0e8c.json
@@ -1,15 +1,13 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "69588eae-a012-48dd-a8f3-fc8a20de0e8c",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Wireless Mouse 3 White",
     "manufacturer": "Xiaomi",
-    "part_numbers": [],
     "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "part_numbers": [],
+    "variant": "White"
   },
+  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
   "general_product_information": {
     "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
   },
@@ -18,7 +16,7 @@
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812792841",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "57943",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/839e7186-4f3d-4089-bfcd-2873b99cd877.json
+++ b/open-db/Mouse/839e7186-4f3d-4089-bfcd-2873b99cd877.json
@@ -1,0 +1,47 @@
+{
+  "opendb_id": "839e7186-4f3d-4089-bfcd-2873b99cd877",
+  "metadata": {
+    "name": "Mi Dual Mode Wireless Mouse Silent Edition Black",
+    "manufacturer": "Xiaomi",
+    "series": "Dual Mode Wireless Mouse Silent Edition",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/mi-dual-mode-wireless-mouse/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177715457",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "26112",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "26112",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "26112",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Mouse/85399116-b977-4368-ac39-02d1d1bebabc.json
+++ b/open-db/Mouse/85399116-b977-4368-ac39-02d1d1bebabc.json
@@ -1,24 +1,22 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "85399116-b977-4368-ac39-02d1d1bebabc",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Wireless Mouse Comfort Edition White",
     "manufacturer": "Xiaomi",
+    "series": "Wireless Mouse Comfort Edition",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "White"
   },
+  "connectivity": ["Wireless 2.4GHz"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-comfort-edition/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812755549",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "59623",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/92957beb-7a46-47ff-a5db-0e87d57e8038.json
+++ b/open-db/Mouse/92957beb-7a46-47ff-a5db-0e87d57e8038.json
@@ -1,24 +1,22 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "92957beb-7a46-47ff-a5db-0e87d57e8038",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Wireless Mouse Comfort Edition Black",
     "manufacturer": "Xiaomi",
+    "series": "Wireless Mouse Comfort Edition",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
     "variant": "Black"
   },
+  "connectivity": ["Wireless 2.4GHz"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-comfort-edition/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812746042",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "59628",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/b93d61ec-98d0-45c2-96c9-1981457b0975.json
+++ b/open-db/Mouse/b93d61ec-98d0-45c2-96c9-1981457b0975.json
@@ -1,15 +1,13 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "b93d61ec-98d0-45c2-96c9-1981457b0975",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Wireless Mouse 3 Blue",
     "manufacturer": "Xiaomi",
-    "part_numbers": [],
     "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "part_numbers": [],
+    "variant": "Blue"
   },
+  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
   "general_product_information": {
     "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
   },
@@ -18,7 +16,7 @@
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812792827",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "57945",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/ea5dd6e8-10a5-4921-b2fd-359534bef306.json
+++ b/open-db/Mouse/ea5dd6e8-10a5-4921-b2fd-359534bef306.json
@@ -1,15 +1,13 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "ea5dd6e8-10a5-4921-b2fd-359534bef306",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Wireless Mouse 3 Pink",
     "manufacturer": "Xiaomi",
-    "part_numbers": [],
     "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "part_numbers": [],
+    "variant": "Pink"
   },
+  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
   "general_product_information": {
     "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
   },
@@ -18,7 +16,7 @@
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812792858",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "57942",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/f1c7e622-e67d-451e-bb42-16f745889d0f.json
+++ b/open-db/Mouse/f1c7e622-e67d-451e-bb42-16f745889d0f.json
@@ -1,24 +1,22 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "f1c7e622-e67d-451e-bb42-16f745889d0f",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Wireless Mouse Lite 2 White",
     "manufacturer": "Xiaomi",
+    "series": "Wireless Mouse Lite 2",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
-    "variant": "Black"
+    "variant": "White"
   },
+  "connectivity": ["Wireless 2.4GHz"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-lite-2/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812792995",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "57958",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Mouse/f4d37495-1488-4cac-9902-d11c85d74571.json
+++ b/open-db/Mouse/f4d37495-1488-4cac-9902-d11c85d74571.json
@@ -1,24 +1,22 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "f4d37495-1488-4cac-9902-d11c85d74571",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Wireless Mouse Lite 2 Black",
     "manufacturer": "Xiaomi",
+    "series": "Wireless Mouse Lite 2",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
     "variant": "Black"
   },
+  "connectivity": ["Wireless 2.4GHz"],
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-lite-2/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6941812792988",
         "region": "all"
       }
     ],
@@ -26,7 +24,7 @@
       {
         "source": "xiaomi",
         "channel": "pl",
-        "source_product_id": "57944",
+        "source_product_id": "57959",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Speaker/19161ac6-f2fb-4a84-820a-ffca9845203e.json
+++ b/open-db/Speaker/19161ac6-f2fb-4a84-820a-ffca9845203e.json
@@ -1,0 +1,32 @@
+{
+  "opendb_id": "19161ac6-f2fb-4a84-820a-ffca9845203e",
+  "metadata": {
+    "name": "Mi Portable Bluetooth Speaker (16W) Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Portable Bluetooth Speaker (16W)",
+    "part_numbers": [],
+    "variant": "Blue"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/mi-portable-bluetooth-speaker/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6971408153473",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "29692",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/1e72edd4-6502-4655-8160-555a5735a1d9.json
+++ b/open-db/Speaker/1e72edd4-6502-4655-8160-555a5735a1d9.json
@@ -1,0 +1,52 @@
+{
+  "opendb_id": "1e72edd4-6502-4655-8160-555a5735a1d9",
+  "metadata": {
+    "name": "Xiaomi Sound Party",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Party",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-party/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948706743",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "65366",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "65366",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "65366",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "65366",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/226c1860-96cb-483c-9771-122aaed48a48.json
+++ b/open-db/Speaker/226c1860-96cb-483c-9771-122aaed48a48.json
@@ -1,32 +1,29 @@
 {
-  "opendb_id": "2c8ba31f-3246-4573-8ce0-31990ff586ab",
-  "connectivity": ["Wireless 2.4GHz", "Bluetooth"],
-  "lighting": [],
-  "grip_types": [],
+  "opendb_id": "226c1860-96cb-483c-9771-122aaed48a48",
   "metadata": {
-    "name": "Xiaomi Wireless Mouse 3 Black",
+    "name": "Xiaomi Smart Speaker (IR Control) Black",
     "manufacturer": "Xiaomi",
+    "series": "Smart Speaker (IR Control)",
     "part_numbers": [],
-    "series": "Wireless Mouse 3",
     "variant": "Black"
   },
   "general_product_information": {
-    "manufacturer_url": "https://www.mi.com/pl/product/xiaomi-wireless-mouse-3/"
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-smart-speaker-ir-control/"
   },
   "identifiers": {
     "version": 1,
     "identifiers": [
       {
         "type": "ean",
-        "value": "6941812792834",
+        "value": "6934177749094",
         "region": "all"
       }
     ],
     "retailer_listings": [
       {
         "source": "xiaomi",
-        "channel": "pl",
-        "source_product_id": "57944",
+        "channel": "it",
+        "source_product_id": "34810",
         "pricing_enabled": true,
         "verified": true
       }

--- a/open-db/Speaker/274e216e-f8b6-4da1-bb88-ac092d2b2072.json
+++ b/open-db/Speaker/274e216e-f8b6-4da1-bb88-ac092d2b2072.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "274e216e-f8b6-4da1-bb88-ac092d2b2072",
+  "metadata": {
+    "name": "Xiaomi Sound Pocket Black",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Pocket",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-pocket/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948702349",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "55688",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "55688",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "55688",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "55688",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/2d3175a0-f1b1-40c1-b09b-d49159ac3122.json
+++ b/open-db/Speaker/2d3175a0-f1b1-40c1-b09b-d49159ac3122.json
@@ -1,0 +1,52 @@
+{
+  "opendb_id": "2d3175a0-f1b1-40c1-b09b-d49159ac3122",
+  "metadata": {
+    "name": "Xiaomi Desktop Speaker",
+    "manufacturer": "Xiaomi",
+    "series": "Desktop Speaker",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-desktop-speaker/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941812793008",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57963",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57963",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57963",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57963",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/2eaa55d8-feb0-434a-be74-6de2a1867ee8.json
+++ b/open-db/Speaker/2eaa55d8-feb0-434a-be74-6de2a1867ee8.json
@@ -1,0 +1,45 @@
+{
+  "opendb_id": "2eaa55d8-feb0-434a-be74-6de2a1867ee8",
+  "metadata": {
+    "name": "Xiaomi Soundbar 2.0",
+    "manufacturer": "Xiaomi",
+    "series": "Soundbar 2.0",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-soundbar-2ch/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948704206",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "59771",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "59771",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "59771",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/40a587db-09bb-4fc8-b7df-3fa718352e48.json
+++ b/open-db/Speaker/40a587db-09bb-4fc8-b7df-3fa718352e48.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "40a587db-09bb-4fc8-b7df-3fa718352e48",
+  "metadata": {
+    "name": "Xiaomi Bluetooth Speaker Essential Green",
+    "manufacturer": "Xiaomi",
+    "series": "Bluetooth Speaker Essential",
+    "part_numbers": [],
+    "variant": "Green"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-bluetooth-speaker-essential/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554457563",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "66525",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "66525",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "66525",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/4524473f-a9e2-4a33-89f1-aee8cf4326c3.json
+++ b/open-db/Speaker/4524473f-a9e2-4a33-89f1-aee8cf4326c3.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "4524473f-a9e2-4a33-89f1-aee8cf4326c3",
+  "metadata": {
+    "name": "Xiaomi Sound Pocket Blue Gray",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Pocket",
+    "part_numbers": [],
+    "variant": "Blue Gray"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-pocket/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948709201",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70871",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70871",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70871",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70871",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/46391239-d114-48f9-ad0f-3105885a8237.json
+++ b/open-db/Speaker/46391239-d114-48f9-ad0f-3105885a8237.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "46391239-d114-48f9-ad0f-3105885a8237",
+  "metadata": {
+    "name": "Xiaomi Sound Pocket Pink",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Pocket",
+    "part_numbers": [],
+    "variant": "Pink"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-pocket/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948709218",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70873",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70873",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70873",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70873",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/475e214f-4312-4523-8ff9-34602a0fa8de.json
+++ b/open-db/Speaker/475e214f-4312-4523-8ff9-34602a0fa8de.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "475e214f-4312-4523-8ff9-34602a0fa8de",
+  "metadata": {
+    "name": "Xiaomi Sound Play White",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Play",
+    "part_numbers": [],
+    "variant": "White"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-sound-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948711037",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "79903",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "79903",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "79903",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/483a9309-ede1-46e7-bb60-a99822b80951.json
+++ b/open-db/Speaker/483a9309-ede1-46e7-bb60-a99822b80951.json
@@ -1,0 +1,57 @@
+{
+  "opendb_id": "483a9309-ede1-46e7-bb60-a99822b80951",
+  "metadata": {
+    "name": "Xiaomi Soundbar Pro 2.1 ch",
+    "manufacturer": "Xiaomi",
+    "series": "Soundbar Pro 2.1 ch",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-soundbar-pro-21ch/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948707344",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948707368",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "66954",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "66954",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "66954",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "66960",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/4ac0eec8-9928-425a-b2f2-9dd9788053d3.json
+++ b/open-db/Speaker/4ac0eec8-9928-425a-b2f2-9dd9788053d3.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "4ac0eec8-9928-425a-b2f2-9dd9788053d3",
+  "metadata": {
+    "name": "Xiaomi Sound Outdoor Red",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Outdoor",
+    "part_numbers": [],
+    "variant": "Red"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-outdoor/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948702035",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "54590",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "54590",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "54590",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "54590",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/62fdd411-c1fb-46cf-ae7e-4c4b970f5280.json
+++ b/open-db/Speaker/62fdd411-c1fb-46cf-ae7e-4c4b970f5280.json
@@ -1,0 +1,52 @@
+{
+  "opendb_id": "62fdd411-c1fb-46cf-ae7e-4c4b970f5280",
+  "metadata": {
+    "name": "Xiaomi Bluetooth Speaker",
+    "manufacturer": "Xiaomi",
+    "series": "Bluetooth Speaker",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-bluetooth-speaker/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948703391",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57962",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57962",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57962",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57962",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/66122bf1-fd21-416f-9fe6-8ddded88e8b8.json
+++ b/open-db/Speaker/66122bf1-fd21-416f-9fe6-8ddded88e8b8.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "66122bf1-fd21-416f-9fe6-8ddded88e8b8",
+  "metadata": {
+    "name": "Xiaomi Sound Outdoor Blue",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Outdoor",
+    "part_numbers": [],
+    "variant": "Blue"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-outdoor/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948702042",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "54592",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "54592",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "54592",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "54592",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/68bfd7b1-ccbb-4b44-a37d-f57c8a33c87b.json
+++ b/open-db/Speaker/68bfd7b1-ccbb-4b44-a37d-f57c8a33c87b.json
@@ -1,0 +1,38 @@
+{
+  "opendb_id": "68bfd7b1-ccbb-4b44-a37d-f57c8a33c87b",
+  "metadata": {
+    "name": "Xiaomi Smart Speaker Lite",
+    "manufacturer": "Xiaomi",
+    "series": "Smart Speaker Lite",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-smart-speaker-lite/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177789281",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "40885",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "40885",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/72859e39-3b68-4b64-b148-34201844ed13.json
+++ b/open-db/Speaker/72859e39-3b68-4b64-b148-34201844ed13.json
@@ -1,0 +1,52 @@
+{
+  "opendb_id": "72859e39-3b68-4b64-b148-34201844ed13",
+  "metadata": {
+    "name": "Xiaomi Bluetooth Speaker Mini",
+    "manufacturer": "Xiaomi",
+    "series": "Bluetooth Speaker Mini",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-bluetooth-speaker-mini/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948703384",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "57961",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "57961",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "57961",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "57961",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/7308e832-4010-4001-9ffe-1faae0d55e70.json
+++ b/open-db/Speaker/7308e832-4010-4001-9ffe-1faae0d55e70.json
@@ -1,0 +1,39 @@
+{
+  "opendb_id": "7308e832-4010-4001-9ffe-1faae0d55e70",
+  "metadata": {
+    "name": "Xiaomi Sound Play Green",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Play",
+    "part_numbers": [],
+    "variant": "Green"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/es/product/xiaomi-sound-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948711013",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "79901",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "79901",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/8686efd1-cc1f-485d-afef-d1fb4ca06d28.json
+++ b/open-db/Speaker/8686efd1-cc1f-485d-afef-d1fb4ca06d28.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "8686efd1-cc1f-485d-afef-d1fb4ca06d28",
+  "metadata": {
+    "name": "Xiaomi Sound Outdoor Black",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Outdoor",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-outdoor/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948702028",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "54588",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "54588",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "54588",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "54588",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/9d3e2683-5926-452e-8b8a-63e8921f3286.json
+++ b/open-db/Speaker/9d3e2683-5926-452e-8b8a-63e8921f3286.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "9d3e2683-5926-452e-8b8a-63e8921f3286",
+  "metadata": {
+    "name": "Xiaomi Sound Outdoor Gold",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Outdoor",
+    "part_numbers": [],
+    "variant": "Gold"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-outdoor/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948709164",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70863",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70863",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70863",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70863",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/a4744b84-178f-4650-b431-8ce2cf03cc0e.json
+++ b/open-db/Speaker/a4744b84-178f-4650-b431-8ce2cf03cc0e.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "a4744b84-178f-4650-b431-8ce2cf03cc0e",
+  "metadata": {
+    "name": "Xiaomi Sound Play Black",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Play",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-sound-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948710900",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "78132",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "78132",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "78132",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/a502715a-5535-4a0f-a4d9-d92b6aa0b7c2.json
+++ b/open-db/Speaker/a502715a-5535-4a0f-a4d9-d92b6aa0b7c2.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "a502715a-5535-4a0f-a4d9-d92b6aa0b7c2",
+  "metadata": {
+    "name": "Xiaomi Bluetooth Speaker Essential Black",
+    "manufacturer": "Xiaomi",
+    "series": "Bluetooth Speaker Essential",
+    "part_numbers": [],
+    "variant": "Black"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-bluetooth-speaker-essential/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554457631",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "66524",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "66524",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "66524",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/b7edb05b-717b-4d4a-b5e8-49ebad7b0792.json
+++ b/open-db/Speaker/b7edb05b-717b-4d4a-b5e8-49ebad7b0792.json
@@ -1,0 +1,57 @@
+{
+  "opendb_id": "b7edb05b-717b-4d4a-b5e8-49ebad7b0792",
+  "metadata": {
+    "name": "Xiaomi Soundbar Pro 2.0 ch",
+    "manufacturer": "Xiaomi",
+    "series": "Soundbar Pro 2.0 ch",
+    "part_numbers": []
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-soundbar-pro-2ch/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948707375",
+        "region": "all"
+      },
+      {
+        "type": "ean",
+        "value": "6941948707399",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "66962",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "66962",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "66962",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "66966",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/bb408dd6-cf7b-4422-8feb-bdbbf3b09334.json
+++ b/open-db/Speaker/bb408dd6-cf7b-4422-8feb-bdbbf3b09334.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "bb408dd6-cf7b-4422-8feb-bdbbf3b09334",
+  "metadata": {
+    "name": "Xiaomi Sound Outdoor Green",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Outdoor",
+    "part_numbers": [],
+    "variant": "Green"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-outdoor/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948709171",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "70865",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "70865",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "70865",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "70865",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/d15ba6f6-d952-4b42-b1e6-fb8f9feb4278.json
+++ b/open-db/Speaker/d15ba6f6-d952-4b42-b1e6-fb8f9feb4278.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "d15ba6f6-d952-4b42-b1e6-fb8f9feb4278",
+  "metadata": {
+    "name": "Mi Portable Bluetooth Speaker Mini Gray",
+    "manufacturer": "Xiaomi",
+    "series": "Portable Bluetooth Speaker Mini",
+    "part_numbers": [],
+    "variant": "Gray"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/mi-portable-bluetooth-speaker-mini/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6934177726774",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "30496",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "30496",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "30496",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/de548454-bf54-46b1-be79-d9efd6529da5.json
+++ b/open-db/Speaker/de548454-bf54-46b1-be79-d9efd6529da5.json
@@ -1,0 +1,53 @@
+{
+  "opendb_id": "de548454-bf54-46b1-be79-d9efd6529da5",
+  "metadata": {
+    "name": "Xiaomi Sound Play Purple",
+    "manufacturer": "Xiaomi",
+    "series": "Sound Play",
+    "part_numbers": [],
+    "variant": "Purple"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/it/product/xiaomi-sound-play/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6941948710993",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "79899",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "it",
+        "source_product_id": "79899",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "79899",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "79899",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}

--- a/open-db/Speaker/fc18abc0-2c75-4b78-bc29-3c781fb2a7f8.json
+++ b/open-db/Speaker/fc18abc0-2c75-4b78-bc29-3c781fb2a7f8.json
@@ -1,0 +1,46 @@
+{
+  "opendb_id": "fc18abc0-2c75-4b78-bc29-3c781fb2a7f8",
+  "metadata": {
+    "name": "Xiaomi Desktop Speaker Pro Set Dark",
+    "manufacturer": "Xiaomi",
+    "series": "Desktop Speaker Pro Set",
+    "part_numbers": [],
+    "variant": "Dark"
+  },
+  "general_product_information": {
+    "manufacturer_url": "https://www.mi.com/uk/product/xiaomi-desktop-speaker-pro-set/"
+  },
+  "identifiers": {
+    "version": 1,
+    "identifiers": [
+      {
+        "type": "ean",
+        "value": "6932554457570",
+        "region": "all"
+      }
+    ],
+    "retailer_listings": [
+      {
+        "source": "xiaomi",
+        "channel": "es",
+        "source_product_id": "68181",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "pl",
+        "source_product_id": "68181",
+        "pricing_enabled": true,
+        "verified": true
+      },
+      {
+        "source": "xiaomi",
+        "channel": "uk",
+        "source_product_id": "68181",
+        "pricing_enabled": true,
+        "verified": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Restores the exact catalog patch from #351 (146 added records and four modified records) for continued review after rollback #356. GitHub rejects reopening an already merged PR, so this is its replacement.

Kept as draft because the production create-part endpoint rejects metadata.part_numbers. Resolve and verify the OpenDB create identity contract before merging this again. This PR does not fix that API issue.

Validation: exact patch equality against the original merge's first-parent diff. Original formatting checks passed; current PR checks run normally. Feature diagram: not applicable (restoring catalog data).

## AI-assisted development disclosure

- Model(s): GPT-6
- Agent harness(es): Codex
- Initial user prompt: Undo the recent OpenDB merges and reopen their PRs.
- Sources consulted: Original PR #351, merge diff and Actions logs; rollback #356; GitHub API rejection of reopening a merged PR.
